### PR TITLE
Adapt code style to github.com/niftyn8/elixir_style_guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Faker [![Version](https://img.shields.io/hexpm/v/faker.svg?style=flat-square)](https://hex.pm/packages/faker)[![License](https://img.shields.io/hexpm/l/faker.svg?style=flat-square)](https://github.com/igas/faker/blob/master/LICENSE)[![Build Status](https://img.shields.io/travis/igas/faker.svg?style=flat-square)](https://travis-ci.org/igas/faker)[![Issues](https://img.shields.io/github/issues/igas/faker.svg?style=flat-square)](https://github.com/igas/faker/issues)[![Downloads](https://img.shields.io/hexpm/dt/faker.svg?style=flat-square)](https://hex.pm/packages/faker)[![Donation](https://img.shields.io/gratipay/igas.svg?style=flat-square)](https://gratipay.com/igas/)
 
-**Faker** is pure [Elixir](http://elixir-lang.org/) library for generating fake
-data.
+**Faker** is a pure [Elixir](http://elixir-lang.org/) library for generating
+fake data.
 
 Inspired by:
 
@@ -12,32 +12,32 @@ Inspired by:
 * Erlang [fakerl](https://github.com/mawuli-ypa/fakerl)
 * Haskell [faker](https://github.com/gazay/faker)
 
-# Install
+## Install
 
-In your mix.exs, add the `:faker` project to your dependencies (optionally
-include the version):
+In your `mix.exs` file, add the `:faker` project to your dependencies
+(optionally include the version):
 
-~~~elixir
+``` elixir
   defp deps do
-    [ {:faker, "~> 0.4.0"} ]
+    [{:faker, "~> 0.4.0"}]
   end
-~~~
+```
 
-Next, you'll need to add :faker  to your applications, so mix will know to
-start `Faker`:
+Do a `mix deps.get` to fetch the dependency. That's it.
 
-~~~elixir
+Next, you'll need to add `:faker` to the list of applications, so that Mix will
+know to start `Faker`:
+
+``` elixir
   def application do
     [
       applications: [:logger, :faker],
       env: [locale: :en]
     ]
   end
-~~~
+```
 
-Do a `mix deps.get` to fetch the dependency. That's it.
-
-# Generators / Providers
+## Generators / Providers
 
 * **Address**
   * `building_number()`
@@ -89,29 +89,30 @@ Do a `mix deps.get` to fetch the dependency. That's it.
   * `suffix()`
   * `title()`
 
-# Thanks
+## Thanks
 
 [![Sponsored by Evil Martians](https://evilmartians.com/badges/sponsored-by-evil-martians.svg)](http://evilmartians.com/)
 
-# TODO
+## TODO
 
 * Add more generators
 * Check performance
 * Add documentation
 * Promote library
 
-# Troubleshooting
+## Troubleshooting
 
 * If you get a message like the one below when you call `Faker.Address.city`,
 you need to add `:faker` to your application's mix file, in the `applications`
 function, as above.
-~~~
+
+``` elixir
 ** (FunctionClauseError) no function clause matching in Faker.Address.city_count/1
     lib/faker/address.ex:48: Faker.Address.city_count(nil)
     lib/faker/address.ex:41: Faker.Address.city/0
-~~~
+```
 
-# Tools
+## Tools
 
 Faker designed as lightweight library, because of it it can be easily used with
 other tools.

--- a/lib/faker/avatar.ex
+++ b/lib/faker/avatar.ex
@@ -20,11 +20,11 @@ defmodule Faker.Avatar do
 
   defp bg do
     :random.seed(:erlang.now)
-    hd(Enum.shuffle(["", "/bgset_bg1", "/bgset_bg2"]))
+    ~w(/bgset_bg1 /bgset_bg2) |> Enum.shuffle |> List.first
   end
 
   defp set do
     :random.seed(:erlang.now)
-    hd(Enum.shuffle(["/set_set1", "/set_set2", "/set_set3"]))
+    ~w(/set_set1 /set_set2 /set_set3) |> Enum.shuffle |> List.first
   end
 end

--- a/lib/faker/commerce.ex
+++ b/lib/faker/commerce.ex
@@ -50,6 +50,6 @@ defmodule Faker.Commerce do
   end
 
   def price do
-    :crypto.rand_uniform(1, 10001)/100.0
+    :crypto.rand_uniform(1, 10001) / 100.0
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Faker.Mixfile do
 
   defp deps do
     [
-      { :poison, "~> 1.3.0" }
+      {:poison, "~> 1.3.0"}
     ]
   end
 
@@ -30,7 +30,7 @@ defmodule Faker.Mixfile do
       files: ["lib", "priv", "mix.exs", "mix.lock"],
       contributors: ["Igor Kapkov"],
       licenses: ["MIT"],
-      links: %{ "Github" => "https://github.com/igas/faker" }
+      links: %{"Github" => "https://github.com/igas/faker"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Faker.Mixfile do
       app: :faker,
       version: "0.4.1",
       elixir: "~> 1.0.0",
-      description: "Faker is pure Elixir library for generating fake data.",
+      description: "Faker is a pure Elixir library for generating fake data.",
       package: package,
       deps: deps
     ]
@@ -30,7 +30,7 @@ defmodule Faker.Mixfile do
       files: ["lib", "priv", "mix.exs", "mix.lock"],
       contributors: ["Igor Kapkov"],
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/igas/faker"}
+      links: %{"GitHub" => "https://github.com/igas/faker"}
     ]
   end
 end


### PR DESCRIPTION
I adapted some code to the style defined in https://github.com/niftyn8/elixir_style_guide. Just a couple of extra spaces and some use of the `|>` operator.

I also did some *minor* changes to the formatting of README.md and `mix.exs`.