### PR TITLE
Changed image_urls to https

### DIFF
--- a/priv/internet.json
+++ b/priv/internet.json
@@ -25,10 +25,9 @@
         "https://#{domain_name}"
       ],
       "image_url": [
-        "http://placekitten.com/#{:crypto.rand_uniform(1, 1024)}/#{:crypto.rand_uniform(1, 1024)}",
-        "http://placehold.it/#{:crypto.rand_uniform(1, 1024)}x#{:crypto.rand_uniform(1, 1024)}",
-        "http://www.lorempixum.com/#{:crypto.rand_uniform(1, 1024)}/#{:crypto.rand_uniform(1, 1024)}",
-        "http://dummyimage.com/#{:crypto.rand_uniform(1, 1024)}x#{:crypto.rand_uniform(1, 1024)}"
+        "https://placekitten.com/#{:crypto.rand_uniform(1, 1024)}/#{:crypto.rand_uniform(1, 1024)}",
+        "https://placehold.it/#{:crypto.rand_uniform(1, 1024)}x#{:crypto.rand_uniform(1, 1024)}",
+        "https://dummyimage.com/#{:crypto.rand_uniform(1, 1024)}x#{:crypto.rand_uniform(1, 1024)}"
       ]
     },
     "values": {


### PR DESCRIPTION
removed lorempixum since their TLS cert is invalid.

Unless http is explicitly needed, this would be helpful as Chrome prevents loading insecure resources from secure sites.