### PR TITLE
Add US phone number generator

### DIFF
--- a/lib/faker/phone/en_us.ex
+++ b/lib/faker/phone/en_us.ex
@@ -1,0 +1,84 @@
+defmodule Faker.Phone.EnUs do
+  @moduledoc """
+  This follows the rules outlined in the North American Numbering Plan
+  at https://en.wikipedia.org/wiki/North_American_Numbering_Plan.
+
+  The NANP number format may be summarized in the notation NPA-NXX-xxxx:
+
+  The allowed ranges for NPA (area code) are: [2–9] for the first digit, and
+  [0-9] for the second and third digits. The NANP is not assigning area codes
+  with 9 as the second digit.
+
+  The allowed ranges for NXX (central office/exchange) are: [2–9] for the first
+  digit, and [0–9] for both the second and third digits (however, in geographic
+  area codes the third digit of the exchange cannot be 1 if the second digit is
+  also 1).
+
+  The allowed ranges for xxxx (subscriber number) are [0–9] for each of the four
+  digits.
+  """
+
+  @doc """
+  Returns a random US phone number
+
+  Possible returned formats:
+
+    (123) 456-7890
+    123/456-7890
+    123-456-7890
+    123.456.7890
+    1234567890
+  """
+  @spec phone() :: String.t
+  def phone do
+    case digit(0, 3) do
+      0 -> "(#{area_code}) #{exchange_code}-#{subscriber_number}"
+      1 -> "#{area_code}/#{exchange_code}-#{subscriber_number}"
+      _ ->
+        sep = std_separator
+        "#{area_code}#{sep}#{exchange_code}#{sep}#{subscriber_number}"
+    end
+  end
+
+  @doc """
+  Returns a random area code
+  """
+  @spec area_code() :: String.t
+  def area_code do
+    [digit(2, 9), digit(0, 8), digit(0, 9)] |> Enum.join
+  end
+
+  @doc """
+  Returns a random exchange code
+  """
+  @spec exchange_code() :: String.t
+  def exchange_code do
+    second_dig = digit(0, 9)
+    third_dig =
+      case second_dig do
+        1 -> digit(2, 9)
+        _ -> digit(1, 9)
+      end
+    [digit(2, 9), second_dig, third_dig] |> Enum.join
+  end
+
+  @doc """
+  Returns a random subscriber number `n` digits long
+  """
+  @spec subscriber_number(n :: Integer.t) :: String.t
+  def subscriber_number(n) when is_integer(n) do
+    Faker.format(String.duplicate("#", n))
+  end
+  @spec subscriber_number() :: String.t
+  def subscriber_number, do: subscriber_number(4)
+
+  @doc """
+  Returns a random extension `n` digits long
+  """
+  defdelegate extension(n), to: __MODULE__, as: :subscriber_number
+  defdelegate extension, to: __MODULE__, as: :subscriber_number
+
+  defp std_separator, do: Enum.at(["-", ".", ""], digit(0, 3))
+
+  defp digit(min, max), do: :crypto.rand_uniform(min, max)
+end

--- a/test/faker/phone/en_us_test.exs
+++ b/test/faker/phone/en_us_test.exs
@@ -1,0 +1,68 @@
+defmodule Faker.Phone.EnUsTest do
+  use ExUnit.Case, async: true
+  import Faker.Phone.EnUs
+
+  defp repeat_test(fun) do
+    for _ <- 1..100, do: fun.()
+  end
+
+  defp phone_digits do
+    Regex.scan(~r/[0-9]/, phone)
+    |> List.flatten
+    |> Enum.join
+  end
+
+  test "phone/0", do: assert is_binary(phone)
+
+  test "area_code/0" do
+    assert is_binary(area_code)
+    assert String.length(area_code) == 3
+  end
+
+  test "exchange_code/0" do
+    assert is_binary(exchange_code)
+    assert String.length(exchange_code) == 3
+  end
+
+  test "subscriber_number/0" do
+    assert is_binary(subscriber_number)
+    assert String.length(subscriber_number) == 4
+  end
+
+  test "subscriber_number/1" do
+    assert String.length(subscriber_number(3)) == 3
+  end
+
+  test "extension/0" do
+    assert is_binary(extension)
+    assert String.length(extension) == 4
+  end
+
+  test "extension/1" do
+    assert String.length(extension(2)) == 2
+  end
+
+  test "phone second digit of area code is not 9" do
+    repeat_test fn ->
+      assert String.at(phone_digits, 1) != "9"
+    end
+  end
+
+  test "phone is a valid length" do
+    repeat_test fn ->
+      assert String.length(phone_digits) == 10
+    end
+  end
+
+  test "phone central office segment does not start with 1" do
+    repeat_test fn ->
+      assert String.at(phone_digits, 3) != "1"
+    end
+  end
+
+  test "phone central office segment doesn't end with 11" do
+    repeat_test fn ->
+      assert String.slice(phone_digits, 4, 2) != "11"
+    end
+  end
+end


### PR DESCRIPTION
Hello. This PR adds US phone number support, though it suffers the same locale issues as PR #41/issue #23... Would `phone_us` and `phone_uk` work around the locale issue until it can be sorted?
