### PR TITLE
Remove unnecessary import in lib/faker/en_gb.ex

### DIFF
--- a/lib/faker/phone/en_gb.ex
+++ b/lib/faker/phone/en_gb.ex
@@ -1,5 +1,4 @@
 defmodule Faker.Phone.EnGb do
-  import Faker, only: [format: 1]
 
   @moduledoc """
   Functions for contact data in English


### PR DESCRIPTION
The extra import was producing a warning when faker is compiled.