### PR TITLE
Updated email functions to receive a name

### DIFF
--- a/lib/faker/internet.ex
+++ b/lib/faker/internet.ex
@@ -42,7 +42,7 @@ defmodule Faker.Internet do
   """
   @spec email() :: String.t
   def email(name \\ user_name) do
-    "#{name}@#{domain_name}"
+    "#{String.downcase(name)}@#{domain_name}"
   end
 
   @doc """
@@ -50,7 +50,7 @@ defmodule Faker.Internet do
   """
   @spec free_email() :: String.t
   def free_email(name \\ user_name) do
-    "#{name}@#{free_email_service}"
+    "#{String.downcase(name)}@#{free_email_service}"
   end
 
   @doc """
@@ -58,7 +58,7 @@ defmodule Faker.Internet do
   """
   @spec safe_email() :: String.t
   def safe_email(name \\ user_name) do
-    "#{name}@example.#{:random.seed(:os.timestamp);hd(Enum.shuffle(~w(org com net)))}"
+    "#{String.downcase(name)}@example.#{:random.seed(:os.timestamp);hd(Enum.shuffle(~w(org com net)))}"
   end
 
   @doc """

--- a/lib/faker/internet.ex
+++ b/lib/faker/internet.ex
@@ -41,24 +41,24 @@ defmodule Faker.Internet do
   Returns a complete email based on a domain name
   """
   @spec email() :: String.t
-  def email do
-    "#{user_name}@#{domain_name}"
+  def email(name \\ user_name) do
+    "#{name}@#{domain_name}"
   end
 
   @doc """
   Returns a complete free email based on a free email service [gmail, yahoo, hotmail]
   """
   @spec free_email() :: String.t
-  def free_email do
-    "#{user_name}@#{free_email_service}"
+  def free_email(name \\ user_name) do
+    "#{name}@#{free_email_service}"
   end
 
   @doc """
   Returns a safe email
   """
   @spec safe_email() :: String.t
-  def safe_email do
-    "#{user_name}@example.#{:random.seed(:os.timestamp);hd(Enum.shuffle(~w(org com net)))}"
+  def safe_email(name \\ user_name) do
+    "#{name}@example.#{:random.seed(:os.timestamp);hd(Enum.shuffle(~w(org com net)))}"
   end
 
   @doc """

--- a/test/faker/internet_test.exs
+++ b/test/faker/internet_test.exs
@@ -13,12 +13,18 @@ defmodule InternetTest do
     assert is_binary(Faker.Internet.domain_word)
   end
 
-  test "email/0" do
+  test "email/1" do
     assert is_binary(Faker.Internet.email)
+
+    name = "john"
+    assert Faker.Internet.email(name) =~ "#{name}@"
   end
 
-  test "free_email/0" do
+  test "free_email/1" do
     assert is_binary(Faker.Internet.free_email)
+
+    name = "john"
+    assert Faker.Internet.free_email(name) =~ "#{name}@"
   end
 
   test "free_email_service/0" do
@@ -40,8 +46,11 @@ defmodule InternetTest do
     assert Regex.match?(~r/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/, Faker.Internet.mac_address)
   end
 
-  test "safe_email/0" do
+  test "safe_email/1" do
     assert is_binary(Faker.Internet.safe_email)
+
+    name = "john"
+    assert Faker.Internet.safe_email(name) =~ "#{name}@"
   end
 
   test "user_name/0" do


### PR DESCRIPTION
Hi!
I was using your library to create some fake data, and I needed the emails to have the same `user_name` as a previously generated `Faker.Name.first_name`. I have updated the email functions so they can receive a `name` parameter which defaults to the `user_name` they were already using:

```
iex(1)> first_name = Faker.Name.first_name
"Hector"

-- Passing a name

iex(2)> Faker.Internet.email first_name
"hector@bergnaum.com"
iex(3)> Faker.Internet.free_email first_name
"hector@gmail.com"
iex(4)> Faker.Internet.safe_email first_name
"hector@example.net"

-- Default functionality

iex(5)> Faker.Internet.email
"leif1989@barton.name"
iex(6)> Faker.Internet.free_email
"federico2026@gmail.com"
iex(7)> Faker.Internet.safe_email
"katarina_boehm@example.net"
```

I hope you find it helpful :)
Cheers!