### PR TITLE
Support NATO phoentic alphabet

### DIFF
--- a/lib/faker/nato.ex
+++ b/lib/faker/nato.ex
@@ -1,0 +1,62 @@
+defmodule Faker.Nato do
+  import Faker, only: [sampler: 2]
+
+  @moduledoc """
+  Functions for generating NATO alphabet data
+  """
+
+  @doc """
+  Returns a random letter NATO code
+  """
+  @spec letter_code_word :: String.t
+  sampler :letter_code_word, ["ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO", "FOXTROT", "GOLF", "HOTEL", "INDIA", "JULIETT", "KILO", "LIMA", "MIKE", "NOVEMBER", "OSCAR", "PAPA", "QUEBEC", "ROMEO", "SIERRA", "TANGO", "UNIFORM", "VICTOR", "WHISKEY", "XRAY", "YANKEE", "ZULU"]
+
+  @doc """
+  Returns a random digit NATO code
+  """
+  @spec digit_code_word :: String.t
+  sampler :digit_code_word, ["ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT", "NINE", "ZERO"]
+
+  @doc """
+  Returns the NATO stop code
+  """
+  @spec stop_code_word :: String.t
+  def stop_code_word, do: "STOP"
+
+  @doc """
+  Returns a random NATO callsign of the form [alpha]-[alpha]-[digit]
+  """
+  @spec callsign() :: String.t
+  def callsign, do: format("?-?-#")
+
+  @doc """
+  Formats a string using the NATO alphabet.
+
+  It replaces `"#"` to a random NATO digit, `"?"` to random NATO letter
+  and `"."` to the stop code.
+  """
+  @spec format(String.t) :: String.t
+  def format(str) when is_binary(str) do
+    format(str, "")
+  end
+
+  defp format(<<"#" :: utf8, tail :: binary>>, acc) do
+    format(tail, <<acc :: binary, "#{digit_code_word}">>)
+  end
+
+  defp format(<<"?" :: utf8, tail :: binary>>, acc) do
+    format(tail, <<acc :: binary, "#{letter_code_word}">>)
+  end
+
+  defp format(<<"." :: utf8, tail :: binary>>, acc) do
+    format(tail, <<acc :: binary, "#{stop_code_word}">>)
+  end
+
+  defp format(<<other :: utf8, tail :: binary>>, acc) do
+    format(tail, <<acc :: binary, other>>)
+  end
+
+  defp format("", acc) do
+    acc
+  end
+end

--- a/test/faker/nato_test.exs
+++ b/test/faker/nato_test.exs
@@ -1,0 +1,26 @@
+defmodule NatoTest do
+  use ExUnit.Case, async: true
+
+  test "letter_code_word/0" do
+    assert is_binary(Faker.Nato.letter_code_word)
+  end
+
+  test "digit_code_word/0" do
+    assert is_binary(Faker.Nato.digit_code_word)
+  end
+
+  test "stop_code_word/0" do
+    assert is_binary(Faker.Nato.stop_code_word)
+  end
+
+  test "callsign/0" do
+    assert is_binary(Faker.Nato.callsign)
+  end
+
+  test "format/1" do
+    assert is_binary(Faker.Nato.format(""))
+    assert Faker.Nato.format("? Team") =~ ~r/\w{4} Team/
+    assert Faker.Nato.format("hey") == "hey"
+    assert Faker.Nato.format(". it") == "STOP it"
+  end
+end


### PR DESCRIPTION
Adds a module for generating strings from the [nato phonetic alphabet](https://en.wikipedia.org/wiki/NATO_phonetic_alphabet). I've found this really useful for generating categories/severity levels/team names etc.

Examples
---------

```
Faker.Nato.letter_code_word
# => "ALPHA"

Faker.Nato.digit_code_word
# => "ONE"

Faker.Nato.format("?-#-?")
# => "ALPHA SIX ZULU"

Faker.Nato.callsign
# => "DELTA XRAY FIVE"
```


@igas what do you think? I made use of it in the ruby [ffaker](https://github.com/ffaker/ffaker) gem. Be awesome to have access to it in elixir too. (Cheers for putting together this library by the way - exactly what I was looking for).