### PR TITLE
Fix Faker.Lorem.paragraphs/1 typespec

### DIFF
--- a/lib/faker/lorem.ex
+++ b/lib/faker/lorem.ex
@@ -53,11 +53,11 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a string with a random amount of paragraphs (in between the specified
+  Returns a list with a random amount of paragraphs (in between the specified
   range)
   If no range is specified it defaults to 2..5
   """
-  @spec paragraphs(Range.t) :: String.t
+  @spec paragraphs(Range.t) :: list(String.t)
   def paragraphs(range \\ %Range{first: 2, last: 5})
 
   def paragraphs(%Range{first: first, last: last}) do
@@ -65,9 +65,9 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a string with an amount of paragraphs equal to the parameter provided
+  Returns a list with an amount of paragraphs equal to the parameter provided
   """
-  @spec paragraphs(integer) :: String.t
+  @spec paragraphs(integer) :: list(String.t)
   def paragraphs(num) do
     Stream.repeatedly(&paragraph/0)
     |> Enum.take(num)


### PR DESCRIPTION
The function `Faker.Lorem.paragraphs/1` type specification declares a `String.t` return type, but the function does actually return a `list(String.t)` (in fact, the tests were already checking if the returned value was a list).

You can see this incorrect type specification in the following example:
```elixir
iex(1)> s Faker.Lorem.paragraphs
@spec paragraphs(integer()) :: String.t()
@spec paragraphs(Range.t()) :: String.t()
iex(2)> is_list(Faker.Lorem.paragraphs)
true
```

Dialyzer was also emitting the following type error on this function:
```
lib/faker/lorem.ex:60: Invalid type specification for function 'Elixir.Faker.Lorem':paragraphs/1. The success typing is (integer() | #{'__struct__':='Elixir.Range', 'first':=binary() | integer(), 'last':=integer(), _=>_}) -> [any()]
```

After updating the typespec (and the documentation) of this function the type error has been fixed. And Dialyzer does not report it anymore.
```elixir
iex(1)> s Faker.Lorem.paragraphs
@spec paragraphs(integer()) :: [String.t()]
@spec paragraphs(Range.t()) :: [String.t()]
iex(2)> is_list(Faker.Lorem.paragraphs)
true
```