### PR TITLE
Add support for DateTime and NaiveDateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 * `Faker.Date` [@tobyhinloopen][]
 * `Faker.Date.between` [@anthonator][]
 * `Faker.DateTime` [@anthonator][]
+* `Faker.NaiveDateTime` [@anthonator][]
 * `Faker.Nato` [@petehamilton][]
 * `Faker.Pokemon` [@orieken][]
 * `Faker.App.semver` [@wojtekmach][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 * `Faker.Code.iban` [@tobyhinloopen][]
 * `Faker.Beer` [@orieken][]
 * `Faker.Date` [@tobyhinloopen][]
+* `Faker.Date.between` [@anthonator][]
+* `Faker.DateTime` [@anthonator][]
 * `Faker.Nato` [@petehamilton][]
 * `Faker.Pokemon` [@orieken][]
 * `Faker.App.semver` [@wojtekmach][]

--- a/USAGE.md
+++ b/USAGE.md
@@ -7,6 +7,7 @@
 - [Faker.Commerce](#fakercommerce)
 - [Faker.Company](#fakercompany)
 - [Faker.Date](#fakerdate)
+- [Faker.DateTime](#fakerdatetime)
 - [Faker.File](#fakerfile)
 - [Faker.Internet](#fakerinternet)
 - [Faker.Internet.UserAgent](#fakerinternetuseragent)
@@ -177,6 +178,30 @@ Faker.Date.date_of_birth(10..19) #=> ~D[2004-05-15]
 Faker.Date.forward(4) #=> ~D[2016-12-25]
 
 Faker.Date.backward(4) #=> ~D[2016-12-20]
+
+Faker.Date.between(~D[2016-12-20], ~D[2016-12-25]) #=> ~D[2016-12-23]
+```
+
+### Faker.DateTime
+
+```elixir
+Faker.DateTime.forward(4)
+#=> %DateTime{calendar: Calendar.ISO, day: 25, hour: 6,
+#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
+#=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
+#=>  zone_abbr: "UTC"}
+
+Faker.DateTime.backward(4)
+#=> %DateTime{calendar: Calendar.ISO, day: 20, hour: 6,
+#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
+#=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
+#=>  zone_abbr: "UTC"}
+
+Faker.DateTime.between(~D[2016-12-20], ~D[2016-12-25])
+#=> %DateTime{calendar: Calendar.ISO, day: 23, hour: 6,
+#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
+#=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
+#=>  zone_abbr: "UTC"}
 ```
 
 ### Faker.File

--- a/USAGE.md
+++ b/USAGE.md
@@ -8,6 +8,7 @@
 - [Faker.Company](#fakercompany)
 - [Faker.Date](#fakerdate)
 - [Faker.DateTime](#fakerdatetime)
+- [Faker.NaiveDateTime](#fakernaivedatetime)
 - [Faker.File](#fakerfile)
 - [Faker.Internet](#fakerinternet)
 - [Faker.Internet.UserAgent](#fakerinternetuseragent)
@@ -197,11 +198,30 @@ Faker.DateTime.backward(4)
 #=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
 #=>  zone_abbr: "UTC"}
 
-Faker.DateTime.between(~D[2016-12-20], ~D[2016-12-25])
+Faker.DateTime.between(from_datetime, to_datetime)
 #=> %DateTime{calendar: Calendar.ISO, day: 23, hour: 6,
 #=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
 #=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
 #=>  zone_abbr: "UTC"}
+```
+
+### Faker.NaiveDateTime
+
+```elixir
+Faker.DateTime.forward(4)
+#=> %NaiveDateTime{calendar: Calendar.ISO, day: 25, hour: 6,
+#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
+#=>  year: 2016}
+
+Faker.DateTime.backward(4)
+#=> %NaiveDateTime{calendar: Calendar.ISO, day: 20, hour: 6,
+#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
+#=>  year: 2016}
+
+Faker.DateTime.between(from_naivedatetime, to_naivedatetime)
+#=> %NaiveDateTime{calendar: Calendar.ISO, day: 23, hour: 6,
+#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
+#=>  year: 2016}
 ```
 
 ### Faker.File

--- a/USAGE.md
+++ b/USAGE.md
@@ -198,7 +198,11 @@ Faker.DateTime.backward(4)
 #=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
 #=>  zone_abbr: "UTC"}
 
-Faker.DateTime.between(from_datetime, to_datetime)
+from = DateTime.utc_now()
+to = DateTime.utc_now() |> DateTime.to_unix
+to = to + 86400 * 10 |> DateTime.from_unix!
+
+Faker.DateTime.between(from, to)
 #=> %DateTime{calendar: Calendar.ISO, day: 23, hour: 6,
 #=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
 #=>  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2016,
@@ -208,20 +212,11 @@ Faker.DateTime.between(from_datetime, to_datetime)
 ### Faker.NaiveDateTime
 
 ```elixir
-Faker.NaiveDateTime.forward(4)
-#=> %NaiveDateTime{calendar: Calendar.ISO, day: 25, hour: 6,
-#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
-#=>  year: 2016}
+Faker.NaiveDateTime.forward(4) #=> ~N[2016-12-25 06:02:17.922180]
 
-Faker.NaiveDateTime.backward(4)
-#=> %NaiveDateTime{calendar: Calendar.ISO, day: 20, hour: 6,
-#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
-#=>  year: 2016}
+Faker.NaiveDateTime.backward(4) #=> ~N[2016-12-20 06:02:17.922180]
 
-Faker.NaiveDateTime.between(from_naivedatetime, to_naivedatetime)
-#=> %NaiveDateTime{calendar: Calendar.ISO, day: 23, hour: 6,
-#=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
-#=>  year: 2016}
+Faker.NaiveDateTime.between(~N[2016-12-20 00:00:00], ~N[2016-12-25 00:00:00]) #=> ~N[2016-12-23 06:02:17.922180]
 ```
 
 ### Faker.File

--- a/USAGE.md
+++ b/USAGE.md
@@ -208,17 +208,17 @@ Faker.DateTime.between(from_datetime, to_datetime)
 ### Faker.NaiveDateTime
 
 ```elixir
-Faker.DateTime.forward(4)
+Faker.NaiveDateTime.forward(4)
 #=> %NaiveDateTime{calendar: Calendar.ISO, day: 25, hour: 6,
 #=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
 #=>  year: 2016}
 
-Faker.DateTime.backward(4)
+Faker.NaiveDateTime.backward(4)
 #=> %NaiveDateTime{calendar: Calendar.ISO, day: 20, hour: 6,
 #=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
 #=>  year: 2016}
 
-Faker.DateTime.between(from_naivedatetime, to_naivedatetime)
+Faker.NaiveDateTime.between(from_naivedatetime, to_naivedatetime)
 #=> %NaiveDateTime{calendar: Calendar.ISO, day: 23, hour: 6,
 #=>  microsecond: {922180, 6},  minute: 2, month: 12, second: 17,
 #=>  year: 2016}

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -50,7 +50,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     @doc """
-    Returns a random date between two dates, start date and end date not
+    Returns a random date between two dates, today included
     included
     """
     @spec between(Date.t, Date.t) :: Date.t

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -50,8 +50,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     @doc """
-    Returns a random date between two dates, today included
-    included
+    Returns a random date between two dates
     """
     @spec between(Date.t, Date.t) :: Date.t
     def between(from, to) do

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -55,16 +55,8 @@ if Version.match?(System.version(), ">= 1.3.0") do
     """
     @spec between(Date.t, Date.t) :: Date.t
     def between(from, to) do
-      Faker.DateTime.between(to_datetime(from), to_datetime(to))
+      Faker.DateTime.between(from, to)
       |> DateTime.to_date
-    end
-
-    # private
-
-    defp to_datetime(date) do
-      %DateTime{calendar: Calendar.ISO, day: date.day, hour: 0, minute: 0,
-                month: date.month, second: 0, time_zone: "Etc/UTC",
-                utc_offset: 0, std_offset: 0, year: date.year, zone_abbr: "UTC"}
     end
   end
 end

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -4,8 +4,6 @@ if Version.match?(System.version(), ">= 1.3.0") do
     Functions for generating dates
     """
 
-    @seconds_per_day 86400
-
     @doc """
     Returns a random date of birth for a person with an age specified by a number or range
 
@@ -47,15 +45,26 @@ if Version.match?(System.version(), ">= 1.3.0") do
     """
     @spec forward(integer) :: Date.t
     def forward(days) do
-      unix_now =
-        DateTime.utc_now()
-        |> DateTime.to_unix()
+      Faker.DateTime.forward(days)
+      |> DateTime.to_date
+    end
 
-      sign = if days < 0, do: -1, else: 1
+    @doc """
+    Returns a random date between two dates, start date and end date not
+    included
+    """
+    @spec between(Date.t, Date.t) :: Date.t
+    def between(from, to) do
+      Faker.DateTime.between(to_datetime(from), to_datetime(to))
+      |> DateTime.to_date
+    end
 
-      unix_now + sign * @seconds_per_day * :crypto.rand_uniform(1, abs(days))
-      |> DateTime.from_unix!()
-      |> DateTime.to_date()
+    # private
+
+    defp to_datetime(date) do
+      %DateTime{calendar: Calendar.ISO, day: date.day, hour: 0, minute: 0,
+                month: date.month, second: 0, time_zone: "Etc/UTC",
+                utc_offset: 0, std_offset: 0, year: date.year, zone_abbr: "UTC"}
     end
   end
 end

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -27,15 +27,26 @@ if Version.match?(System.version(), ">= 1.3.0") do
     @doc """
     Returns a random date between two dates, today included
     """
+    @spec between(Date.t, Date.t) :: DateTime.t
+    def between(%Date{} = from, %Date{} = to) do
+      between(to_datetime(from), to_datetime(to))
+    end
+
+    @doc """
+    Returns a random date between two dates, today included
+    """
     @spec between(DateTime.t, DateTime.t) :: DateTime.t
     def between(from, to) do
-      unix_from = to_timestamp(from)
-      unix_to = to_timestamp(to)
-
-      unix_between(unix_from, unix_to)
+      unix_between(to_timestamp(from), to_timestamp(to))
     end
 
     # private
+
+    defp to_datetime(date) do
+      %DateTime{calendar: Calendar.ISO, day: date.day, hour: 0, minute: 0,
+                month: date.month, second: 0, time_zone: "Etc/UTC",
+                utc_offset: 0, std_offset: 0, year: date.year, zone_abbr: "UTC"}
+    end
 
     defp to_timestamp(datetime) do
       DateTime.to_unix(datetime, :microseconds)

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -29,7 +29,15 @@ if Version.match?(System.version(), ">= 1.3.0") do
     """
     @spec between(Date.t, Date.t) :: DateTime.t
     def between(%Date{} = from, %Date{} = to) do
-      between(to_datetime(from), to_datetime(to))
+      between(date_to_datetime(from), date_to_datetime(to))
+    end
+
+    @doc """
+    Returns a random `NaiveDateTime.t` between two `NaiveDateTime.t`'s
+    """
+    @spec between(NaiveDateTime.t, NaiveDateTime.t) :: DateTime.t
+    def between(%NaiveDateTime{} = from, %NaiveDateTime{} = to) do
+      between(naivedatetime_to_datetime(from), naivedatetime_to_datetime(to))
     end
 
     @doc """
@@ -42,10 +50,18 @@ if Version.match?(System.version(), ">= 1.3.0") do
 
     # private
 
-    defp to_datetime(date) do
+    defp date_to_datetime(date) do
       %DateTime{calendar: Calendar.ISO, day: date.day, hour: 0, minute: 0,
                 month: date.month, second: 0, time_zone: "Etc/UTC",
                 utc_offset: 0, std_offset: 0, year: date.year, zone_abbr: "UTC"}
+    end
+
+    defp naivedatetime_to_datetime(naivedatetime) do
+      %DateTime{calendar: naivedatetime.calendar, day: naivedatetime.day,
+                hour: naivedatetime.hour, minute: naivedatetime.minute,
+                month: naivedatetime.month, second: naivedatetime.second,
+                time_zone: "Etc/UTC", utc_offset: 0, std_offset: 0,
+                year: naivedatetime.year, zone_abbr: "UTC"}
     end
 
     defp to_timestamp(datetime) do

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -15,30 +15,37 @@ if Version.match?(System.version(), ">= 1.3.0") do
     """
     @spec forward(integer) :: DateTime.t
     def forward(days) do
-      unix_from = DateTime.utc_now() |> DateTime.to_unix(:microseconds)
+      sign = if days < 0, do: -1, else: 1
 
-      unix_between(unix_from, days)
+      today = DateTime.utc_now() |> to_timestamp
+      from = today + sign * @microseconds_per_day # add or subtract extra day to avoid returning today
+      to = from + @microseconds_per_day * days
+
+      unix_between(from, to)
     end
 
     @doc """
-    Returns a random date between two dates, start date and end date not
-    included
+    Returns a random date between two dates, today included
     """
     @spec between(DateTime.t, DateTime.t) :: DateTime.t
     def between(from, to) do
-      unix_from = DateTime.to_unix(from, :microseconds)
-      unix_to = DateTime.to_unix(to, :microseconds)
-      days = round(Float.floor((unix_to - unix_from) / @microseconds_per_day))
+      unix_from = to_timestamp(from)
+      unix_to = to_timestamp(to)
 
-      unix_between(unix_from, days)
+      unix_between(unix_from, unix_to)
     end
 
     # private
 
-    defp unix_between(unix_from, days) do
-      sign = if days < 0, do: -1, else: 1
+    defp to_timestamp(datetime) do
+      DateTime.to_unix(datetime, :microseconds)
+    end
 
-      unix_from + sign * @microseconds_per_day * :crypto.rand_uniform(1, abs(days))
+    defp unix_between(from, to) do
+      diff = to - from
+      sign = if diff < 0, do: -1, else: 1
+
+      from + sign * :crypto.rand_uniform(0, abs(diff))
       |> DateTime.from_unix!(:microseconds)
     end
   end

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -25,7 +25,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     @doc """
-    Returns a random date between two dates, today included
+    Returns a random date & time between two dates
     """
     @spec between(Date.t, Date.t) :: DateTime.t
     def between(%Date{} = from, %Date{} = to) do
@@ -33,7 +33,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     @doc """
-    Returns a random date between two dates, today included
+    Returns a random `DateTime.t` between two `DateTime.t`'s
     """
     @spec between(DateTime.t, DateTime.t) :: DateTime.t
     def between(from, to) do

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -33,7 +33,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     @doc """
-    Returns a random `NaiveDateTime.t` between two `NaiveDateTime.t`'s
+    Returns a random `DateTime.t` between two `NaiveDateTime.t`'s
     """
     @spec between(NaiveDateTime.t, NaiveDateTime.t) :: DateTime.t
     def between(%NaiveDateTime{} = from, %NaiveDateTime{} = to) do

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -1,0 +1,45 @@
+if Version.match?(System.version(), ">= 1.3.0") do
+  defmodule Faker.DateTime do
+    @microseconds_per_day 86400000000
+
+    @doc """
+    Returns a random date in the past up to N days, today not included
+    """
+    @spec backward(integer) :: DateTime.t
+    def backward(days) do
+      forward(-days)
+    end
+
+    @doc """
+    Returns a random date in the future up to N days, today not included
+    """
+    @spec forward(integer) :: DateTime.t
+    def forward(days) do
+      unix_from = DateTime.utc_now() |> DateTime.to_unix(:microseconds)
+
+      unix_between(unix_from, days)
+    end
+
+    @doc """
+    Returns a random date between two dates, start date and end date not
+    included
+    """
+    @spec between(DateTime.t, DateTime.t) :: DateTime.t
+    def between(from, to) do
+      unix_from = DateTime.to_unix(from, :microseconds)
+      unix_to = DateTime.to_unix(to, :microseconds)
+      days = round(Float.floor((unix_to - unix_from) / @microseconds_per_day))
+
+      unix_between(unix_from, days)
+    end
+
+    # private
+
+    defp unix_between(unix_from, days) do
+      sign = if days < 0, do: -1, else: 1
+
+      unix_from + sign * @microseconds_per_day * :crypto.rand_uniform(1, abs(days))
+      |> DateTime.from_unix!(:microseconds)
+    end
+  end
+end

--- a/lib/faker/naivedatetime.ex
+++ b/lib/faker/naivedatetime.ex
@@ -1,0 +1,29 @@
+if Version.match?(System.version(), ">= 1.3.0") do
+  defmodule Faker.NaiveDateTime do
+    @doc """
+    Returns a random date in the past up to N days, today not included
+    """
+    @spec backward(integer) :: NaiveDateTime.t
+    def backward(days) do
+      forward(-days)
+    end
+
+    @doc """
+    Returns a random date in the future up to N days, today not included
+    """
+    @spec forward(integer) :: NaiveDateTime.t
+    def forward(days) do
+      Faker.DateTime.forward(days)
+      |> DateTime.to_naive
+    end
+
+    @doc """
+    Returns a random `NaiveDateTime.t` between two `NaiveDateTime.t`'s
+    """
+    @spec between(NaiveDateTime.t, NaiveDateTime.t) :: NaiveDateTime.t
+    def between(from, to) do
+      Faker.DateTime.between(from, to)
+      |> DateTime.to_naive
+    end
+  end
+end

--- a/test/faker/date_test.exs
+++ b/test/faker/date_test.exs
@@ -31,8 +31,8 @@ if Version.match?(System.version(), ">= 1.3.0") do
       to_date = ~D[2017-01-10]
       between_date = Faker.Date.between(from_date, to_date)
       assert %Date{year: year, month: month, day: day} = between_date
-      assert from_date.year < year || from_date.month < month || from_date.day < day
-      assert to_date.year > year || from_date.month > month || to_date.day > day
+      assert from_date.year <= year || from_date.month <= month || from_date.day <= day
+      assert to_date.year >= year || from_date.month >= month || to_date.day >= day
     end
 
     defp age(%Date{year: year, month: month, day: day}) do

--- a/test/faker/date_test.exs
+++ b/test/faker/date_test.exs
@@ -26,6 +26,15 @@ if Version.match?(System.version(), ">= 1.3.0") do
       assert now().year > year || now().month > month || now().day > day
     end
 
+    test "between/2" do
+      from_date = ~D[2017-01-01]
+      to_date = ~D[2017-01-10]
+      between_date = Faker.Date.between(from_date, to_date)
+      assert %Date{year: year, month: month, day: day} = between_date
+      assert from_date.year < year || from_date.month < month || from_date.day < day
+      assert to_date.year > year || from_date.month > month || to_date.day > day
+    end
+
     defp age(%Date{year: year, month: month, day: day}) do
       %Date{ year: current_year, month: current_month, day: current_day } = now()
       already_aged_this_year = current_month > month || current_month == month && day >= current_day

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -1,0 +1,44 @@
+if Version.match?(System.version(), ">= 1.3.0") do
+  defmodule DateTimeTest do
+    use ExUnit.Case, async: true
+
+    @microseconds_per_day 86400000000
+
+    test "forward/1" do
+      forwarded_date = Faker.DateTime.forward(10)
+      assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
+        = forwarded_date
+      assert now().year > year || now().month > month || now().day > day
+        || now().second > second || now().microsecond > microsecond
+    end
+
+    test "backward/1" do
+      backward_date = Faker.DateTime.backward(10)
+      assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
+        = backward_date
+      assert now().year > year || now().month > month || now().day > day
+        || now().second > second || now().microsecond > microsecond
+    end
+
+    test "between/2" do
+      from_date = now()
+      to_date = add_days(from_date, 10)
+      between_date = Faker.DateTime.between(from_date, to_date)
+      assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
+        = between_date
+      assert from_date.year < year || from_date.month < month || from_date.day < day
+        || from_date.second < second || from_date.microsecond < microsecond
+      assert to_date.year > year || to_date.month > month || to_date.day > day
+        || to_date.second > second || to_date.microsecond > microsecond
+    end
+
+    defp now do
+      DateTime.utc_now()
+    end
+
+    defp add_days(date, days) do
+      DateTime.to_unix(date) + @microseconds_per_day * days
+      |> DateTime.from_unix!(:microseconds)
+    end
+  end
+end

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -2,8 +2,6 @@ if Version.match?(System.version(), ">= 1.3.0") do
   defmodule DateTimeTest do
     use ExUnit.Case, async: true
 
-    @microseconds_per_day 86400000000
-
     test "forward/1" do
       now = DateTime.utc_now()
       forwarded_date = Faker.DateTime.forward(10)

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -5,19 +5,21 @@ if Version.match?(System.version(), ">= 1.3.0") do
     @microseconds_per_day 86400000000
 
     test "forward/1" do
+      now = now()
       forwarded_date = Faker.DateTime.forward(10)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
         = forwarded_date
-      assert now().year > year || now().month > month || now().day > day
-        || now().second > second || now().microsecond > microsecond
+      assert now.year > year || now.month > month || now.day > day
+        || now.second > second || now.microsecond > microsecond
     end
 
     test "backward/1" do
+      now = now()
       backward_date = Faker.DateTime.backward(10)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
         = backward_date
-      assert now().year > year || now().month > month || now().day > day
-        || now().second > second || now().microsecond > microsecond
+      assert now.year > year || now.month > month || now.day > day
+        || now.second > second || now.microsecond > microsecond
     end
 
     test "between/2" do

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -5,7 +5,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     @microseconds_per_day 86400000000
 
     test "forward/1" do
-      now = now()
+      now = DateTime.utc_now()
       forwarded_date = Faker.DateTime.forward(10)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
         = forwarded_date
@@ -14,7 +14,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     test "backward/1" do
-      now = now()
+      now = DateTime.utc_now()
       backward_date = Faker.DateTime.backward(10)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
         = backward_date
@@ -23,7 +23,7 @@ if Version.match?(System.version(), ">= 1.3.0") do
     end
 
     test "between/2" do
-      from_date = now()
+      from_date = DateTime.utc_now()
       to_date = add_days(from_date, 10)
       between_date = Faker.DateTime.between(from_date, to_date)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
@@ -32,10 +32,6 @@ if Version.match?(System.version(), ">= 1.3.0") do
         || from_date.second < second || from_date.microsecond < microsecond
       assert to_date.year > year || to_date.month > month || to_date.day > day
         || to_date.second > second || to_date.microsecond > microsecond
-    end
-
-    defp now do
-      DateTime.utc_now()
     end
 
     defp add_days(date, days) do

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -24,19 +24,14 @@ if Version.match?(System.version(), ">= 1.3.0") do
 
     test "between/2" do
       from_date = DateTime.utc_now()
-      to_date = add_days(from_date, 10)
+      to_date = Faker.DateTime.forward(50)
       between_date = Faker.DateTime.between(from_date, to_date)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
         = between_date
-      assert from_date.year < year || from_date.month < month || from_date.day < day
-        || from_date.second < second || from_date.microsecond < microsecond
-      assert to_date.year > year || to_date.month > month || to_date.day > day
-        || to_date.second > second || to_date.microsecond > microsecond
-    end
-
-    defp add_days(date, days) do
-      DateTime.to_unix(date) + @microseconds_per_day * days
-      |> DateTime.from_unix!(:microseconds)
+      assert from_date.year <= year || from_date.month <= month || from_date.day <= day
+        || from_date.second <= second || from_date.microsecond <= microsecond
+      assert to_date.year >= year || to_date.month >= month || to_date.day >= day
+        || to_date.second >= second || to_date.microsecond >= microsecond
     end
   end
 end

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -9,8 +9,8 @@ if Version.match?(System.version(), ">= 1.3.0") do
       forwarded_date = Faker.DateTime.forward(10)
       assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
         = forwarded_date
-      assert now.year > year || now.month > month || now.day > day
-        || now.second > second || now.microsecond > microsecond
+      assert now.year < year || now.month < month || now.day < day
+        || now.second < second || now.microsecond < microsecond
     end
 
     test "backward/1" do

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -7,31 +7,57 @@ if Version.match?(System.version(), ">= 1.3.0") do
     test "forward/1" do
       now = DateTime.utc_now()
       forwarded_date = Faker.DateTime.forward(10)
-      assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
-        = forwarded_date
-      assert now.year < year || now.month < month || now.day < day
-        || now.second < second || now.microsecond < microsecond
+      assert %DateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = forwarded_date
+      assert now.year < year || now.month < month
+        || now.hour < hour || now.minute < minute
+        || now.day < day || now.second < second
+        || now.microsecond < microsecond
     end
 
     test "backward/1" do
       now = DateTime.utc_now()
       backward_date = Faker.DateTime.backward(10)
-      assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
-        = backward_date
-      assert now.year > year || now.month > month || now.day > day
-        || now.second > second || now.microsecond > microsecond
+      assert %DateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = backward_date
+      assert now.year > year || now.month > month
+        || now.hour > hour || now.minute > minute
+        || now.day > day || now.second > second
+        || now.microsecond > microsecond
     end
 
-    test "between/2" do
+    test "between/2 for Date.t" do
+      from_date = DateTime.utc_now() |> DateTime.to_date
+      to_date = Faker.DateTime.forward(50) |> DateTime.to_date
+      between_date = Faker.DateTime.between(from_date, to_date)
+      assert %DateTime{year: year, month: month, day: day}
+        = between_date
+      assert from_date.year <= year || from_date.month <= month
+        || from_date.day <= day
+      assert to_date.year >= year || to_date.month >= month
+        || to_date.day >= day
+    end
+
+    test "between/2 for DateTime.t" do
       from_date = DateTime.utc_now()
       to_date = Faker.DateTime.forward(50)
       between_date = Faker.DateTime.between(from_date, to_date)
-      assert %DateTime{year: year, month: month, day: day, second: second, microsecond: microsecond}
-        = between_date
-      assert from_date.year <= year || from_date.month <= month || from_date.day <= day
-        || from_date.second <= second || from_date.microsecond <= microsecond
-      assert to_date.year >= year || to_date.month >= month || to_date.day >= day
-        || to_date.second >= second || to_date.microsecond >= microsecond
+      assert %DateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = between_date
+      assert from_date.year <= year || from_date.month <= month
+        || from_date.hour <= hour || from_date.minute <= minute
+        || from_date.day <= day || from_date.second <= second
+        || from_date.microsecond <= microsecond
+      assert to_date.year >= year || to_date.month >= month
+        || to_date.hour >= hour || to_date.minute >= minute
+        || to_date.day >= day || to_date.second >= second
+        || to_date.microsecond >= microsecond
     end
   end
 end

--- a/test/faker/datetime_test.exs
+++ b/test/faker/datetime_test.exs
@@ -42,6 +42,32 @@ if Version.match?(System.version(), ">= 1.3.0") do
         || to_date.day >= day
     end
 
+    test "between/2 for NaiveDateTime.t" do
+      from_datetime = DateTime.utc_now()
+      from_date = from_datetime |> DateTime.to_date
+      from_time = from_datetime |> DateTime.to_time
+      {:ok, from_naivedatetime} = NaiveDateTime.new(from_date, from_time)
+
+      to_datetime = Faker.DateTime.forward(50)
+      to_date = to_datetime |> DateTime.to_date
+      to_time = to_datetime |> DateTime.to_time
+      {:ok, to_naivedatetime} = NaiveDateTime.new(to_date, to_time)
+
+      between_date = Faker.DateTime.between(from_naivedatetime, to_naivedatetime)
+      assert %DateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = between_date
+      assert from_naivedatetime.year <= year || from_naivedatetime.month <= month
+        || from_naivedatetime.hour <= hour || from_naivedatetime.minute <= minute
+        || from_naivedatetime.day <= day || from_naivedatetime.second <= second
+        || from_naivedatetime.microsecond <= microsecond
+      assert to_naivedatetime.year >= year || to_naivedatetime.month >= month
+        || to_naivedatetime.hour >= hour || to_naivedatetime.minute >= minute
+        || to_naivedatetime.day >= day || to_naivedatetime.second >= second
+        || to_naivedatetime.microsecond >= microsecond
+    end
+
     test "between/2 for DateTime.t" do
       from_date = DateTime.utc_now()
       to_date = Faker.DateTime.forward(50)

--- a/test/faker/naivedatetime_test.exs
+++ b/test/faker/naivedatetime_test.exs
@@ -1,0 +1,65 @@
+if Version.match?(System.version(), ">= 1.3.0") do
+  defmodule NaiveDateTimeTest do
+    use ExUnit.Case, async: true
+
+    test "forward/1" do
+      now_datetime = DateTime.utc_now()
+      now_date = now_datetime |> DateTime.to_date
+      now_time = now_datetime |> DateTime.to_time
+      {:ok, now} = NaiveDateTime.new(now_date, now_time)
+
+      forwarded_date = Faker.NaiveDateTime.forward(10)
+      assert %NaiveDateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = forwarded_date
+      assert now.year < year || now.month < month
+        || now.hour < hour || now.minute < minute
+        || now.day < day || now.second < second
+        || now.microsecond < microsecond
+    end
+
+    test "backward/1" do
+      now_datetime = DateTime.utc_now()
+      now_date = now_datetime |> DateTime.to_date
+      now_time = now_datetime |> DateTime.to_time
+      {:ok, now} = NaiveDateTime.new(now_date, now_time)
+
+      backward_date = Faker.NaiveDateTime.backward(10)
+      assert %NaiveDateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = backward_date
+      assert now.year > year || now.month > month
+        || now.hour > hour || now.minute > minute
+        || now.day > day || now.second > second
+        || now.microsecond > microsecond
+    end
+
+    test "between/2" do
+      from_datetime = DateTime.utc_now()
+      from_date = from_datetime |> DateTime.to_date
+      from_time = from_datetime |> DateTime.to_time
+      {:ok, from_naivedatetime} = NaiveDateTime.new(from_date, from_time)
+
+      to_datetime = Faker.DateTime.forward(50)
+      to_date = to_datetime |> DateTime.to_date
+      to_time = to_datetime |> DateTime.to_time
+      {:ok, to_naivedatetime} = NaiveDateTime.new(to_date, to_time)
+
+      between_date = Faker.DateTime.between(from_naivedatetime, to_naivedatetime)
+      assert %DateTime{
+        year: year, month: month, day: day, hour: hour, minute: minute,
+        second: second, microsecond: microsecond
+      } = between_date
+      assert from_naivedatetime.year <= year || from_naivedatetime.month <= month
+        || from_naivedatetime.hour <= hour || from_naivedatetime.minute <= minute
+        || from_naivedatetime.day <= day || from_naivedatetime.second <= second
+        || from_naivedatetime.microsecond <= microsecond
+      assert to_naivedatetime.year >= year || to_naivedatetime.month >= month
+        || to_naivedatetime.hour >= hour || to_naivedatetime.minute >= minute
+        || to_naivedatetime.day >= day || to_naivedatetime.second >= second
+        || to_naivedatetime.microsecond >= microsecond
+    end
+  end
+end


### PR DESCRIPTION
@igas @tobyhinloopen 

This is currently a work in progress. I just want to get some feedback on what I've accomplished so far and see if this is something you'd accept.

I've gone ahead and implemented support for `DateTime`. This includes the `forward/1` and `backward/1` functions. I've also implemented a `between/2` function that I thought may accomplish what #74 is trying to achieve. If not I think it would still be useful.

I also standardized the relevant `Faker.Date` functions around `Faker.DateTime`. This way all the logic is shared.

If what I've put together so far looks good I'll implement support for `NaiveDateTime` next.

I've added:

- [x] USAGE.md docs if applicable
- [x] CHANGELOG.md
