### PR TITLE
Remove unused import from Faker.Internet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+* Stopped a warning from an unused import of `Faker` in `Faker.Internet`
+
 ### Security
 
 ## 0.8.0

--- a/lib/faker/internet.ex
+++ b/lib/faker/internet.ex
@@ -1,6 +1,4 @@
 defmodule Faker.Internet do
-  import Faker, only: [sampler: 2]
-
   alias Faker.Name.En, as: Name
 
   @moduledoc """


### PR DESCRIPTION
With this unused import being present in Faker 0.8.0, I see this warning when I run `mix deps.compile`:

```
warning: unused import Faker
  lib/faker/internet.ex:2
```

I've added:

- [ ] ~USAGE.md docs if applicable~
- [x] CHANGELOG.md
