### PR TITLE
Geohash support added

### DIFF
--- a/lib/faker/geohash.ex
+++ b/lib/faker/geohash.ex
@@ -1,0 +1,20 @@
+defmodule Faker.Geohash do
+    import Faker.Address, only: [latitude: 0, longitude: 0]
+    alias Faker.Address
+
+    @moduledoc """
+    Function for generate geohashes.
+    """
+    
+    @doc """
+    Return random geohash.
+    """
+    @spec geohash() :: String.t
+    def geohash do
+      import Geohash, only: [encode: 2]
+  
+      Geohash.encode(latitude(), longitude(), rand_precision())
+    end
+
+    defp rand_precision, do: :rand.uniform(8)
+  end

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule Faker.Mixfile do
       {:earmark, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
+      {:geohash, "~> 1.0", optional: true},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "geohash": {:hex, :geohash, "1.0.2", "d02f8c974704105d3c6cc7e722647319aa601c86169693710866a550277dc41e", [], [], "hexpm"}}

--- a/test/faker/geohash_test.exs
+++ b/test/faker/geohash_test.exs
@@ -1,0 +1,7 @@
+defmodule GeohashTest do
+    use ExUnit.Case, async: true
+  
+    test "geohash/0" do
+      assert is_binary(Faker.Geohash.geohash)
+    end
+  end


### PR DESCRIPTION
Hey :)

I've added support for generating geohashes. This commit adds an [optional dependency](https://hex.pm/packages/geohash) to mix.exs.

Whats a geohash? It's an hash computed with Faker.Address.{longitude, latitude} and might look like this: ezs42