### PR TITLE
Corrected dateranges for Faker.Date.date_of_birth

### DIFF
--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -25,24 +25,21 @@ defmodule Faker.Date do
     potential_latest_date = {earliest_year + 1, month_now, day_now}
 
     earliest_date =
-      case :calendar.valid_date(potential_earliest_date) do
-        true -> {earliest_year, month_now, day_now + 1}
-        false -> {earliest_year, 3, 1}
-      end
+      if :calendar.valid_date(potential_earliest_date),
+        do: {earliest_year, month_now, day_now + 1},
+        else: {earliest_year, 3, 1}
 
     latest_date =
-      case :calendar.valid_date(potential_latest_date) do
-        true -> {earliest_year + 1, month_now, day_now}
-        false -> {earliest_year + 1, 2, 28}
-      end
+      if :calendar.valid_date(potential_latest_date),
+        do: {earliest_year + 1, month_now, day_now},
+        else: {earliest_year + 1, 2, 28}
 
     earliest_as_seconds = :calendar.datetime_to_gregorian_seconds({earliest_date, {0, 0, 0}})
     lastest_as_seconds = :calendar.datetime_to_gregorian_seconds({latest_date, {23, 59, 59}})
 
     {chosen_date, _time} =
-      (lastest_as_seconds - earliest_as_seconds)
-      |> :rand.uniform()
-      |> Kernel.+(earliest_as_seconds)
+      earliest_as_seconds..lastest_as_seconds
+      |> Enum.random()
       |> :calendar.gregorian_seconds_to_datetime()
 
     {:ok, result} = Date.from_erl(chosen_date)
@@ -50,20 +47,10 @@ defmodule Faker.Date do
   end
 
   @spec date_of_birth(Range.t()) :: Date.t()
-  def date_of_birth(%Range{first: first, last: last}) do
-    random_age =
-      cond do
-        first < last ->
-          first + :rand.uniform(last - first + 1) - 1
-
-        first > last ->
-          last + :rand.uniform(first - last + 1) - 1
-
-        true ->
-          first
-      end
-
-    date_of_birth(random_age)
+  def date_of_birth(age_range) do
+    age_range
+    |> Enum.random()
+    |> date_of_birth()
   end
 
   @doc """

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -66,7 +66,6 @@ defmodule Faker.Date do
     date_of_birth(random_age)
   end
 
-
   @doc """
   Returns a random date in the past up to N days, today not included
   """

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -12,12 +12,11 @@ defmodule Faker.Date do
       date_of_birth(1) #=> ~D[2015-12-06]
       date_of_birth(10..19) #=> ~D[2004-05-15]
   """
-  @spec date_of_birth() :: Date.t
+  @spec date_of_birth() :: Date.t()
   def date_of_birth(age_or_range \\ 18..99)
 
-  @spec date_of_birth(integer) :: Date.t
+  @spec date_of_birth(integer) :: Date.t()
   def date_of_birth(age) when is_integer(age) do
-
     {{year_now, month_now, day_now}, _time} = :calendar.local_time()
 
     earliest_year = year_now - (age + 1)
@@ -37,31 +36,35 @@ defmodule Faker.Date do
         false -> {earliest_year + 1, 2, 28}
       end
 
-    earliest_as_seconds = :calendar.datetime_to_gregorian_seconds({earliest_date, {0,0,0}})
-    lastest_as_seconds = :calendar.datetime_to_gregorian_seconds({latest_date, {23,59,59}})
-    
+    earliest_as_seconds = :calendar.datetime_to_gregorian_seconds({earliest_date, {0, 0, 0}})
+    lastest_as_seconds = :calendar.datetime_to_gregorian_seconds({latest_date, {23, 59, 59}})
+
     {chosen_date, _time} =
       (lastest_as_seconds - earliest_as_seconds)
       |> :rand.uniform()
       |> Kernel.+(earliest_as_seconds)
-      |> :calendar.gregorian_seconds_to_datetime;
+      |> :calendar.gregorian_seconds_to_datetime()
 
     {:ok, result} = Date.from_erl(chosen_date)
     result
   end
 
-
-  @spec date_of_birth(Range.t) :: Date.t
+  @spec date_of_birth(Range.t()) :: Date.t()
   def date_of_birth(%Range{first: first, last: last}) do
-    {{current_year, current_month, current_day}, _time} = :calendar.local_time()
-    random_month = :crypto.rand_uniform(1, 13)
-    random_day = :crypto.rand_uniform(1, 29)
-    already_aged_this_year = current_month > random_month || current_month == random_month && random_day >= current_day
-    random_year = current_year - :crypto.rand_uniform(first, last) + (if already_aged_this_year, do: 1, else: 0)
-    {:ok, date} = Date.new random_year, random_month, random_day
-    date
-  end
+    random_age =
+      cond do
+        first < last ->
+          first + :rand.uniform(last - first + 1) - 1
 
+        first > last ->
+          last + :rand.uniform(first - last + 1) - 1
+
+        true ->
+          first
+      end
+
+    date_of_birth(random_age)
+  end
 
 
   @doc """

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -17,8 +17,39 @@ defmodule Faker.Date do
 
   @spec date_of_birth(integer) :: Date.t
   def date_of_birth(age) when is_integer(age) do
-    date_of_birth(%Range{first: age, last: age + 1})
+
+    {{year_now, month_now, day_now}, _time} = :calendar.local_time()
+
+    earliest_year = year_now - (age + 1)
+
+    potential_earliest_date = {earliest_year, month_now, day_now + 1}
+    potential_latest_date = {earliest_year + 1, month_now, day_now}
+
+    earliest_date =
+      case :calendar.valid_date(potential_earliest_date) do
+        true -> {earliest_year, month_now, day_now + 1}
+        false -> {earliest_year, 3, 1}
+      end
+
+    latest_date =
+      case :calendar.valid_date(potential_latest_date) do
+        true -> {earliest_year + 1, month_now, day_now}
+        false -> {earliest_year + 1, 2, 28}
+      end
+
+    earliest_as_seconds = :calendar.datetime_to_gregorian_seconds({earliest_date, {0,0,0}})
+    lastest_as_seconds = :calendar.datetime_to_gregorian_seconds({latest_date, {23,59,59}})
+    
+    {chosen_date, _time} =
+      (lastest_as_seconds - earliest_as_seconds)
+      |> :rand.uniform()
+      |> Kernel.+(earliest_as_seconds)
+      |> :calendar.gregorian_seconds_to_datetime;
+
+    {:ok, result} = Date.from_erl(chosen_date)
+    result
   end
+
 
   @spec date_of_birth(Range.t) :: Date.t
   def date_of_birth(%Range{first: first, last: last}) do
@@ -30,6 +61,8 @@ defmodule Faker.Date do
     {:ok, date} = Date.new random_year, random_month, random_day
     date
   end
+
+
 
   @doc """
   Returns a random date in the past up to N days, today not included

--- a/test/faker/date_test.exs
+++ b/test/faker/date_test.exs
@@ -35,9 +35,16 @@ defmodule DateTest do
   end
 
   defp age(%Date{year: year, month: month, day: day}) do
-    %Date{ year: current_year, month: current_month, day: current_day } = now()
-    already_aged_this_year = current_month > month || current_month == month && day >= current_day
-    current_year - year + (if already_aged_this_year, do: 1, else: 0)
+    %Date{year: current_year, month: current_month, day: current_day} = now()
+    min_age = current_year - year - 1
+
+    had_birthday_this_year =
+      current_month > month || (current_month == month && current_day >= day)
+
+    case had_birthday_this_year do
+      true -> min_age + 1
+      false -> min_age
+    end
   end
 
   defp now do

--- a/test/faker/date_test.exs
+++ b/test/faker/date_test.exs
@@ -2,7 +2,7 @@ defmodule DateTest do
   use ExUnit.Case, async: true
 
   test "date_of_birth/0" do
-    assert age(Faker.Date.date_of_birth) in 18..99
+    assert age(Faker.Date.date_of_birth()) in 18..99
   end
 
   test "date_of_birth/1 with exact age" do
@@ -41,13 +41,12 @@ defmodule DateTest do
     had_birthday_this_year =
       current_month > month || (current_month == month && current_day >= day)
 
-    case had_birthday_this_year do
-      true -> min_age + 1
-      false -> min_age
-    end
+    if had_birthday_this_year,
+      do: min_age + 1,
+      else: min_age
   end
 
   defp now do
-    DateTime.utc_now |> DateTime.to_date
+    DateTime.utc_now() |> DateTime.to_date()
   end
 end


### PR DESCRIPTION
So, this started out as a supposedly easy hacktoberfest PR,  trying to fix #103 and #96.
I ended up rewriting Faker.Date.date_of_birth to cover the full range of possible birthdays (if not mistaken, including situations involving leapyears), thus hopefully also covering #100 :tada:

Feel free to scrutinize, would be happy about feedback :)


I've added:

- [x] USAGE.md docs if applicable
- [x] CHANGELOG.md
