### PR TITLE
Remove deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Changed
 
+* Replace :crypto.rand_uniform with :rand.uniform [[@anthonyfalzetti][]]
+
 ### Deprecated
 
 ### Removed

--- a/lib/faker/gov/us.ex
+++ b/lib/faker/gov/us.ex
@@ -17,12 +17,12 @@ defmodule Faker.Gov.Us do
   end
 
   defp area do
-    case "#{:crypto.rand_uniform(1, 899)}" do
+    case "#{:rand.uniform(899)}" do
       "666" -> "667"
       n -> n |> String.pad_leading(3, "0")
     end
   end
 
-  defp group, do: "#{:crypto.rand_uniform(1, 99)}" |> String.pad_leading(2, "0")
-  defp serial, do: "#{:crypto.rand_uniform(1, 9999)}" |> String.pad_leading(4, "0")
+  defp group, do: "#{:rand.uniform(99)}" |> String.pad_leading(2, "0")
+  defp serial, do: "#{:rand.uniform(9999)}" |> String.pad_leading(4, "0")
 end


### PR DESCRIPTION
  * Replace :crypto.rand_uniform with :rand.uniform

Fixes https://github.com/igas/faker/issues/130

I've added:

- [ ] USAGE.md docs if applicable
- [ ✔️ ] CHANGELOG.md
