### PR TITLE
Faker.Internet.En, Faker.Internet.Es, Faker.Internet.PtBr APIs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Added
 
+* `Faker.Internet` added Spanish and Brazilian Portuguese translations [@vbrazo][]
 * `Faker.Food` added to generate Food data [@vbrazo][]
 * New maintainer [Toby Hinloopen (@tobyhinloopen)](https://github.com/tobyhinloopen)
 * Gitter chat [room](https://gitter.im/igas/faker) [[@igas][]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 * `Faker.UUID` [[@anthonator][]]
 * mix format config file [[@igas][]]
+* `Faker.Internet` added Spanish and Brazilian Portuguese translations [@vbrazo][]
 
 ### Changed
 
@@ -30,7 +31,6 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Added
 
-* `Faker.Internet` added Spanish and Brazilian Portuguese translations [@vbrazo][]
 * `Faker.Food` added to generate Food data [@vbrazo][]
 * New maintainer [Toby Hinloopen (@tobyhinloopen)](https://github.com/tobyhinloopen)
 * Gitter chat [room](https://gitter.im/igas/faker) [[@igas][]]

--- a/USAGE.md
+++ b/USAGE.md
@@ -23,6 +23,9 @@
 <!-- I -->
 - [Faker.Industry](lib/faker/industry.ex)
 - [Faker.Internet](lib/faker/internet.ex)
+- [Faker.Internet.En](lib/faker/internet/en.ex)
+- [Faker.Internet.Es](lib/faker/internet/es.ex)
+- [Faker.Internet.PtBr](lib/faker/internet/pt_br.ex)
 - [Faker.Internet.UserAgent](lib/faker/internet/user_agent.ex)
 <!-- J -->
 <!-- K -->

--- a/lib/faker/internet/es.ex
+++ b/lib/faker/internet/es.ex
@@ -1,0 +1,19 @@
+defmodule Faker.Internet.Es do
+  import Faker, only: [sampler: 2]
+
+  @moduledoc"""
+  Generating internet related data in Spanish
+  """
+
+  @doc """
+  Returns a random free email service name
+  """
+  @spec free_email_service() :: String
+  sampler :free_email_service, ["gmail.com", "yahoo.com", "hotmail.com"]
+
+  @doc """
+  Returns a random domain suffix
+  """
+  @spec domain_suffix() :: String.t
+  sampler :domain_suffix, ["com", "es", "info", "com.es", "org"]
+end

--- a/lib/faker/internet/pt_br.ex
+++ b/lib/faker/internet/pt_br.ex
@@ -1,0 +1,19 @@
+defmodule Faker.Internet.PtBr do
+  import Faker, only: [sampler: 2]
+
+  @moduledoc"""
+  Generating internet related data in Brazilian Portuguese
+  """
+
+  @doc """
+  Returns a random free email service name
+  """
+  @spec free_email_service() :: String
+  sampler :free_email_service, ["gmail.com", "yahoo.com", "hotmail.com", "live.com", "bol.com.br"]
+
+  @doc """
+  Returns a random domain suffix
+  """
+  @spec domain_suffix() :: String.t
+  sampler :domain_suffix, ["br", "biz", "info", "name", "net", "org"]
+end

--- a/test/faker/internet/en.exs
+++ b/test/faker/internet/en.exs
@@ -1,0 +1,11 @@
+defmodule Internet.EnTest do
+  use ExUnit.Case, async: true
+
+  test "domain_suffix/0" do
+    assert is_binary(Faker.Internet.domain_suffix)
+  end
+
+  test "free_email_service/0" do
+    assert is_binary(Faker.Internet.free_email_service)
+  end
+end

--- a/test/faker/internet/es.exs
+++ b/test/faker/internet/es.exs
@@ -1,0 +1,11 @@
+defmodule Internet.EsTest do
+  use ExUnit.Case, async: true
+
+  test "domain_suffix/0" do
+    assert is_binary(Faker.Internet.domain_suffix)
+  end
+
+  test "free_email_service/0" do
+    assert is_binary(Faker.Internet.free_email_service)
+  end
+end

--- a/test/faker/internet/pt-br.exs
+++ b/test/faker/internet/pt-br.exs
@@ -1,0 +1,11 @@
+defmodule Internet.PtBrTest do
+  use ExUnit.Case, async: true
+
+  test "domain_suffix/0" do
+    assert is_binary(Faker.Internet.domain_suffix)
+  end
+
+  test "free_email_service/0" do
+    assert is_binary(Faker.Internet.free_email_service)
+  end
+end


### PR DESCRIPTION
Add translations for Faker.Internet API
- [x] Spanish
- [x] Brazilian Portuguese

I've added:

- [x] USAGE.md docs if applicable
- [x] CHANGELOG.md

This PR is related to https://github.com/igas/faker/issues/149