### PR TITLE
Fixes misspelling in documentation

### DIFF
--- a/lib/faker/pokemon.ex
+++ b/lib/faker/pokemon.ex
@@ -4,7 +4,7 @@ defmodule Faker.Pokemon do
   """
 
   @doc """
-  Returns a ramdom Pokemon name
+  Returns a random Pokemon name
 
   ## Examples
 


### PR DESCRIPTION
This fixes a misspelled word in the Pokemon docs.

I've added:

- [ ] USAGE.md docs if applicable
- [ ] CHANGELOG.md
