### PR TITLE
Fix Faker.Lorem documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 ### Fixed
 
 * `Faker.App.semver/0` is not generating invalid versions anymore fixed by [[@igas][]] found by [[@ConnorRigby][]]
+* `Faker.Lorem` is not redefining documentation in multiple functions anymore fixed and found by [[@pfac][]]
 
 ### Security
 

--- a/lib/faker/lorem.ex
+++ b/lib/faker/lorem.ex
@@ -19,30 +19,31 @@ defmodule Faker.Lorem do
   sampler :word, ["alias", "consequatur", "aut", "perferendis", "sit", "voluptatem", "accusantium", "doloremque", "aperiam", "eaque", "ipsa", "quae", "ab", "illo", "inventore", "veritatis", "et", "quasi", "architecto", "beatae", "vitae", "dicta", "sunt", "explicabo", "aspernatur", "aut", "odit", "aut", "fugit", "sed", "quia", "consequuntur", "magni", "dolores", "eos", "qui", "ratione", "voluptatem", "sequi", "nesciunt", "neque", "dolorem", "ipsum", "quia", "dolor", "sit", "amet", "consectetur", "adipisci", "velit", "sed", "quia", "non", "numquam", "eius", "modi", "tempora", "incidunt", "ut", "labore", "et", "dolore", "magnam", "aliquam", "quaerat", "voluptatem", "ut", "enim", "ad", "minima", "veniam", "quis", "nostrum", "exercitationem", "ullam", "corporis", "nemo", "enim", "ipsam", "voluptatem", "quia", "voluptas", "sit", "suscipit", "laboriosam", "nisi", "ut", "aliquid", "ex", "ea", "commodi", "consequatur", "quis", "autem", "vel", "eum", "iure", "reprehenderit", "qui", "in", "ea", "voluptate", "velit", "esse", "quam", "nihil", "molestiae", "et", "iusto", "odio", "dignissimos", "ducimus", "qui", "blanditiis", "praesentium", "laudantium", "totam", "rem", "voluptatum", "deleniti", "atque", "corrupti", "quos", "dolores", "et", "quas", "molestias", "excepturi", "sint", "occaecati", "cupiditate", "non", "provident", "sed", "ut", "perspiciatis", "unde", "omnis", "iste", "natus", "error", "similique", "sunt", "in", "culpa", "qui", "officia", "deserunt", "mollitia", "animi", "id", "est", "laborum", "et", "dolorum", "fuga", "et", "harum", "quidem", "rerum", "facilis", "est", "et", "expedita", "distinctio", "nam", "libero", "tempore", "cum", "soluta", "nobis", "est", "eligendi", "optio", "cumque", "nihil", "impedit", "quo", "porro", "quisquam", "est", "qui", "minus", "id", "quod", "maxime", "placeat", "facere", "possimus", "omnis", "voluptas", "assumenda", "est", "omnis", "dolor", "repellendus", "temporibus", "autem", "quibusdam", "et", "aut", "consequatur", "vel", "illum", "qui", "dolorem", "eum", "fugiat", "quo", "voluptas", "nulla", "pariatur", "at", "vero", "eos", "et", "accusamus", "officiis", "debitis", "aut", "rerum", "necessitatibus", "saepe", "eveniet", "ut", "et", "voluptates", "repudiandae", "sint", "et", "molestiae", "non", "recusandae", "itaque", "earum", "rerum", "hic", "tenetur", "a", "sapiente", "delectus", "ut", "aut", "reiciendis", "voluptatibus", "maiores", "doloribus", "asperiores", "repellat"]
 
   @doc """
-  Returns a character list with a random length (in between the specified range)
-  If no range is provided, defaults to 15..255
+  Returns a character list of the given length.
+
+  If a range is provided, the length of the list is random in between the
+  specified range.
+
+  Defaults to a range between 15 and 255 (inclusive).
 
   ## Examples
 
+      iex> Faker.Lorem.characters()
+      #=> 'ej5Qmc45I7DRT3E6gOfCMbWAIz6AQiExiYl0zxXteF10YMeAsV93Q'
+
+      iex> Faker.Lorem.characters(2)
+      #=> '3g'
+
       iex> Faker.Lorem.characters(%Range{first: 1, last: 10})
-      #=> "lHixS3So"
+      #=> 'lHixS3So'
   """
-  @spec characters(Range.t) :: [char]
-  def characters(range \\ %Range{first: 15, last: 255})
+  @spec characters(integer | Range.t) :: [char]
+  def characters(range_or_length \\ %Range{first: 15, last: 255})
 
   def characters(first..last) do
     characters(Faker.random_between(first, last))
   end
 
-  @doc """
-  Returns a character list. It's length is determined by the parameter provided
-
-  ## Examples
-
-      iex> Faker.Lorem.characters(2)
-      #=> ["A", "B"]
-  """
-  @spec characters(integer) :: [char]
   def characters(num) do
     char = &character/0
 
@@ -52,11 +53,20 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a string with a random amount of sentences (in between the specified
-  range)
-  If no range is specified it defaults to 2..5
+  Returns a string with a given amount of sentences.
+
+  If a range is provided, the number of sentences is random in between the
+  specified range.
+  
+  Defaults to a range between 2 and 5 (inclusive).
 
   ## Examples
+
+      iex> Faker.Lorem.paragraph()
+      #=> "Delectus ea velit error cupiditate distinctio suscipit voluptatem et cupiditate. Quia consectetur sunt maiores qui suscipit et sed! Id accusamus ut ut qui reprehenderit sed."
+
+      iex> Faker.Lorem.paragraph(1)
+      #=> "Nemo labore enim"
 
       iex> Faker.Lorem.paragraph(%Range{first: 1, last: 2})
       #=> "Nemo labore enim rem qui praesentium totam non et aut. Beatae molestiae et fugit!"
@@ -68,14 +78,6 @@ defmodule Faker.Lorem do
     paragraph(Faker.random_between(first, last))
   end
 
-  @doc """
-  Returns a string with an amount of sentences equal to the parameter provided
-
-  ## Examples
-
-      iex> Faker.Lorem.paragraph(1)
-      #=> "Nemo labore enim"
-  """
   def paragraph(num) do
     num
     |> sentences()
@@ -83,31 +85,31 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a list with a random amount of paragraphs (in between the specified
-  range)
-  If no range is specified it defaults to 2..5
+  Returns a list with a given amount of paragraphs.
+
+  If a range is provided, the number of paragraphs is random in between the
+  specified range.
+
+  Defaults to a range between 2 and 5 (inclusive)
 
   ## Examples
+
+      iex> Faker.Lorem.paragraphs()
+      #=> ["Placeat quos harum voluptatem quaerat quidem eveniet dolores laboriosam aut. Facilis fugiat fuga quo excepturi aut ratione aut sed! Nihil velit quis magni. Illo et et ducimus labore veritatis."]
+
+      iex> Faker.Lorem.paragraphs(1)
+      #=> ["Placeat quos harum voluptatem quaerat quidem eveniet dolores laboriosam aut.]
 
       iex> Faker.Lorem.paragraphs(%Range{first: 1, last: 2})
       #=> ["Placeat quos harum voluptatem quaerat quidem eveniet dolores laboriosam aut. Facilis fugiat fuga quo excepturi aut ratione aut sed! Nihil velit quis magni. Illo et et ducimus labore veritatis."]
   """
-  @spec paragraphs(Range.t) :: list(String.t)
+  @spec paragraphs(integer | Range.t) :: list(String.t)
   def paragraphs(range \\ %Range{first: 2, last: 5})
 
   def paragraphs(first..last) do
     paragraphs(Faker.random_between(first, last))
   end
 
-  @doc """
-  Returns a list with an amount of paragraphs equal to the parameter provided
-
-  ## Examples
-
-      iex> Faker.Lorem.paragraphs(1)
-      #=> ["Placeat quos harum voluptatem quaerat quidem eveniet dolores laboriosam aut.]
-  """
-  @spec paragraphs(integer) :: list(String.t)
   def paragraphs(num) do
     paragraph = &paragraph/0
 
@@ -117,16 +119,25 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a string with a random amount of words (in between the specified
-  range)
-  If no range is specified it defaults to 4..10
+  Returns a string with a given amount of words.
+  
+  If a range is provided, the number of words is random in between the
+  specified range.
+
+  Defaults to a range between 4 and 10 (inclusive).
 
   ## Examples
+
+      iex> Faker.Lorem.sentence()
+      #=> "Eum et et."
+
+      iex> Faker.Lorem.sentence(1)
+      #=> "Eum et et."
 
       iex> Faker.Lorem.sentence(%Range{first: 1, last: 10})
       #=> "Eum et et."
   """
-  @spec sentence(Range.t) :: String.t
+  @spec sentence(integer | Range.t) :: String.t
   def sentence(range \\ %Range{first: 4, last: 10})
 
   def sentence(first..last) do
@@ -134,15 +145,6 @@ defmodule Faker.Lorem do
     |> sentence(Util.pick([".", ".", ".", "!", "?"]))
   end
 
-  @doc """
-  Returns a string with an amount of words equal to the parameter provided
-
-  ## Examples
-
-      iex> Faker.Lorem.sentence(1)
-      #=> "Eum et et."
-  """
-  @spec sentence(integer) :: String.t
   def sentence(num) do
     sentence(num, Util.pick([".", ".", ".", "!", "?"]))
   end
@@ -168,31 +170,31 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a list of strings each string representing a sentence.
-  The length of the list is random (calculated in between the range provided)
-  If no range is provided it defaults to 2..5
+  Returns a list of strings of the given length, each representing a sentence.
+  
+  If a range is provided, the length of the list is random in between the
+  specified range.
+  
+  Defaults to a range between 2 and 5 (inclusive).
 
   ## Examples
+
+      iex> Faker.Lorem.sentences()
+      #=> ["Eum et et.", "Id eius esse totam voluptas sapiente totam accusantium?"]
+
+      iex> Faker.Lorem.sentences(2)
+      #=> ["Eum et et.", "Id eius esse totam voluptas sapiente totam accusantium?"]
 
       iex> Faker.Lorem.sentences(%Range{first: 1, last: 2})
       #=> ["Eum et et.", "Id eius esse totam voluptas sapiente totam accusantium?"]
   """
-  @spec sentences(Range.t) :: [String.t]
+  @spec sentences(integer | Range.t) :: [String.t]
   def sentences(range \\ 2..5)
 
   def sentences(first..last) do
     sentences(Faker.random_between(first, last))
   end
 
-  @doc """
-  Returns a list of strings of length equal to the parameter provided
-
-  ## Examples
-
-      iex> Faker.Lorem.sentences(2)
-      #=> ["Eum et et.", "Id eius esse totam voluptas sapiente totam accusantium?"]
-  """
-  @spec sentences(integer) :: [String.t]
   def sentences(num) do
     sentence = &sentence/0
 
@@ -202,32 +204,31 @@ defmodule Faker.Lorem do
   end
 
   @doc """
-  Returns a list of strings each representing a word.
-  The length of the list is random (calculated between the range provided)
-  If no range is provided it defaults to 3..6
+  Returns a list of strings of the given length, each representing a word.
+  
+  If a range is provided, the length of the list is random in between the
+  provided range.
+
+  Defaults to a range between 3 and 6.
 
   ## Examples
+
+      iex> Faker.Lorem.words()
+      #=> ["labore", "totam"]
+
+      iex> Faker.Lorem.words(2)
+      #=> ["labore", "totam"]
 
       iex> Faker.Lorem.words(%Range{first: 1, last: 2}))
       #=> ["labore", "totam"]
   """
-  @spec words(Range.t) :: [String.t]
+  @spec words(integer | Range.t) :: [String.t]
   def words(range \\ %Range{first: 3, last: 6})
 
   def words(first..last) do
     words(Faker.random_between(first, last))
   end
 
-  @doc """
-  Returns a list of strings representing a word.
-  The length of the list equals the parameter provided
-
-  ## Examples
-
-      iex> Faker.Lorem.words(2)
-      #=> ["labore", "totam"]
-  """
-  @spec words(integer) :: [String.t]
   def words(num) do
     word = &word/0
 


### PR DESCRIPTION
Why:

* Compiling the project with Elixir 1.7 is currently showing multiple
  warnings regarding the `Faker.Lorem` module:

  ```
  warning: redefining @doc attribute previously set at line X. If you
    want to redefine a previously specified doc, use a definition
    without a body after the original documentation
  ```

  These warnings are shown because the same functions (with the same
  arities) are being documented twice, depending on whether the
  arguments are numbers or ranges.

  As this is the same function for Elixir, despite the provided
  argument, the second `@doc` definition is overriding the first one.

  In fact, this is causing the documentation in [hexdocs] to show
  examples using ranges, but only the documentation for numbers.

This change addresses the issue by:

* Refactoring the Faker.Lorem documentation definitions, fixing the
  warnings and merging the two definitions where relevant.

[hexdocs]: https://hexdocs.pm/faker/Faker.Lorem.html

I've added:

- [x] CHANGELOG.md
