### PR TITLE
Add range matching clause to Faker.Util.pick/1 to avoid enumeration

### DIFF
--- a/lib/faker/util.ex
+++ b/lib/faker/util.ex
@@ -22,6 +22,11 @@ defmodule Faker.Util do
       "2"
   """
   @spec pick(Enum.t()) :: any
+
+  def pick(low..high) do
+    Faker.random_between(low, high) 
+  end
+
   def pick(enum) do
     enum
     |> Enum.to_list()

--- a/lib/faker/util.ex
+++ b/lib/faker/util.ex
@@ -22,9 +22,8 @@ defmodule Faker.Util do
       "2"
   """
   @spec pick(Enum.t()) :: any
-
   def pick(low..high) do
-    Faker.random_between(low, high) 
+    Faker.random_between(low, high)
   end
 
   def pick(enum) do


### PR DESCRIPTION
In the former `Faker.Utils.pick/1` the provided `Enum.t()` would be enumerated turning it into a list. With the update a provided Range.t() `low..high` is no longer enumerated and is used to generate a number between the `low` and `high` with the `Faker.random_between/2` function.

I think this resolves issue #213 
