### PR TITLE
Fix performance regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+* `Faker.Util.pick/1` performance regression [[@aptinio][]]
+
 ### Security
 
 ## 0.11.1

--- a/lib/faker/util.ex
+++ b/lib/faker/util.ex
@@ -23,9 +23,7 @@ defmodule Faker.Util do
   """
   @spec pick(Enum.t()) :: any
   def pick(enum) do
-    enum
-    |> Enum.to_list()
-    |> Enum.at(Faker.random_between(0, Enum.count(enum) - 1))
+    Enum.at(enum, Faker.random_between(0, Enum.count(enum) - 1))
   end
 
   @doc """


### PR DESCRIPTION
Removed `Enum.to_list/1` call since `Enum.at/2` works fine with any enum.

Fixes #213 and fixes #219.

I've added:

- [x] USAGE.md docs if applicable (not applicable)
- [x] CHANGELOG.md
