### PR TITLE
Fix Faker.Internet.remove_special_characters/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Changed
 
+- [ ] Fixed `Faker.Internet.remove_special_characters/1` so that it strips apostrophes and quotes
+
 ### Deprecated
 
 ### Removed

--- a/lib/faker/internet.ex
+++ b/lib/faker/internet.ex
@@ -333,6 +333,6 @@ defmodule Faker.Internet do
   end
 
   defp remove_special_characters(string) do
-    String.replace(string, ~s('"), "")
+    String.replace(string, ~r/('|")/, "")
   end
 end

--- a/test/faker/internet_test.exs
+++ b/test/faker/internet_test.exs
@@ -46,7 +46,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&user_name/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~r/('|")/)
+      refute Regex.match?(~r/('|")/, generated_value)
     end)
   end
 
@@ -54,7 +54,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&email/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~r/('|")/)
+      refute Regex.match?(~r/('|")/, generated_value)
     end)
   end
 
@@ -62,7 +62,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&safe_email/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~r/('|")/)
+      refute Regex.match?(~r/('|")/, generated_value)
     end)
   end
 
@@ -70,7 +70,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&free_email/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~r/('|")/)
+      refute Regex.match?(~r/('|")/, generated_value)
     end)
   end
 
@@ -78,7 +78,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&domain_word/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~r/('|")/)
+      refute Regex.match?(~r/('|")/, generated_value)
     end)
   end
 end

--- a/test/faker/internet_test.exs
+++ b/test/faker/internet_test.exs
@@ -46,7 +46,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&user_name/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~s('"))
+      refute String.contains?(generated_value, ~r/('|")/)
     end)
   end
 
@@ -54,7 +54,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&email/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~s('"))
+      refute String.contains?(generated_value, ~r/('|")/)
     end)
   end
 
@@ -62,7 +62,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&safe_email/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~s('"))
+      refute String.contains?(generated_value, ~r/('|")/)
     end)
   end
 
@@ -70,7 +70,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&free_email/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~s('"))
+      refute String.contains?(generated_value, ~r/('|")/)
     end)
   end
 
@@ -78,7 +78,7 @@ defmodule Faker.InternetTest do
     Stream.repeatedly(&domain_word/0)
     |> Enum.take(@iterations)
     |> Enum.each(fn generated_value ->
-      refute String.contains?(generated_value, ~s('"))
+      refute String.contains?(generated_value, ~r/('|")/)
     end)
   end
 end


### PR DESCRIPTION
### Changes
`Faker.Internet.remove_special_characters/1` didn't actually remove special characters, as the sigil wouldn't match. I've also updated the tests.

To validate, inside an `iex` repl:
``` elixir
iex> Regex.match?(~r/('|")/, "rylan.o'hara@example.net")
true
iex> String.contains?("rylan.o'hara@example.net", ~s('"))
false
```

### I've added:
- [x] CHANGELOG.md

Closes #216 