### PR TITLE
Broken link to lib/faker/code/en.ex removed

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,6 @@
 - [Faker.Cat](lib/faker/cat.ex)
 - [Faker.Cat.En](lib/faker/cat/en.ex)
 - [Faker.Code](lib/faker/code.ex)
-- [Faker.Code.En](lib/faker/code/en.ex)
 - [Faker.Color](lib/faker/color.ex)
 - [Faker.Color.En](lib/faker/color/en.ex)
 - [Faker.Color.Es](lib/faker/color/es.ex)


### PR DESCRIPTION
I've added:
Edits to these files
- [x] USAGE.md docs if applicable

