### PR TITLE
👕  Fix deprecated warning message for microseconds unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+* Fix deprecated `Elixir.DateTime` unit `:microseconds` to `:microsecond` [[@vnegrisolo][]]
+
 * Quotes removal in `Faker.Internet` functions [[@jc00ke][]]
 
 ### Security
@@ -284,6 +286,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 [@tobyhinloopen]: https://github.com/tobyhinloopen
 [@vbrazo]: https://github.com/vbrazo
 [@vforvova]: https://github.com/vforvova
+[@vnegrisolo]: https://github.com/vnegrisolo
 [@wojtekmach]: https://github.com/wojtekmach
 [@yordis]: https://github.com/yordis
 [@zmoshansky]: https://github.com/zmoshansky

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
-* Fix deprecated `Elixir.DateTime` unit `:microseconds` to `:microsecond` [[@vnegrisolo][]]
-
+* Elixir 1.8.0 `DateTime` deprecation [[@vnegrisolo][]]
 * Quotes removal in `Faker.Internet` functions [[@jc00ke][]]
 
 ### Security

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -106,7 +106,7 @@ defmodule Faker.DateTime do
   end
 
   defp to_timestamp(datetime) do
-    DateTime.to_unix(datetime, :microseconds)
+    DateTime.to_unix(datetime, :microsecond)
   end
 
   defp unix_between(from, to) do
@@ -115,6 +115,6 @@ defmodule Faker.DateTime do
 
     date = from + sign * Faker.random_between(0, abs(diff))
 
-    DateTime.from_unix!(date, :microseconds)
+    DateTime.from_unix!(date, :microsecond)
   end
 end


### PR DESCRIPTION
After upgrading to elixir 1.8.0-rc.1 I started to get these warnings:

```
warning: deprecated time unit: :microseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (elixir) lib/calendar/iso.ex:717: Calendar.ISO.precision_for_unit/1
  (elixir) lib/calendar/iso.ex:708: Calendar.ISO.from_unix/2
  (elixir) lib/calendar/datetime.ex:118: DateTime.from_unix/3
  (elixir) lib/calendar/datetime.ex:166: DateTime.from_unix!/3
  (faker) lib/faker/date.ex:64: Faker.Date.forward/1
  test/faker/date_test.exs:19: Faker.DateTest."test forward/1"/1
  (ex_unit) lib/ex_unit/runner.ex:355: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:306: anonymous fn/4 in ExUnit.Runner.spawn_test_monitor/4
```

I've added:

~~- [ ] USAGE.md docs if applicable~~
- [x] CHANGELOG.md
