### PR TITLE
Updated Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 ### Changed
 
 * Use `'hy'` language code instead of `'am'` country code as Armenian locale [[@hovikman][]]
+* Enabled `Faker.DateTime` to be indexed in documentation.
 
 ### Deprecated
 

--- a/lib/faker/datetime.ex
+++ b/lib/faker/datetime.ex
@@ -1,5 +1,7 @@
 defmodule Faker.DateTime do
-  @moduledoc false
+  @moduledoc """
+  Functions for working with `DateTime` values.
+  """
 
   @microseconds_per_day 86_400_000_000
 


### PR DESCRIPTION
This enables documentation to be generated for `Faker.DateTime`.
This'll close [#244][1].


I've added:

- [ ] USAGE.md docs if applicable
- [ ] CHANGELOG.md

[1]: https://github.com/igas/faker/issues/244