### PR TITLE
Fix atom typespecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+- Fixed: `Faker.File` typespecs [[@frm][]]
 - Fix industry tests [[@hovikman][]]
 
 ### Security
@@ -297,6 +298,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 [@elbow-jason]: https://github.com/elbow-jason
 [@fenollp]: https://github.com/fenollp
 [@feyl]: https://github.com/feyl
+[@frm]: https://github.com/frm
 [@gesjeremie]: https://github.com/GesJeremie
 [@gmcintire]: https://github.com/gmcintire
 [@halfdan]: https://github.com/halfdan

--- a/lib/faker/file.ex
+++ b/lib/faker/file.ex
@@ -69,7 +69,7 @@ defmodule Faker.File do
       iex> Faker.File.file_extension(:office)
       "xls"
   """
-  @spec file_extension(:atom) :: String.t()
+  @spec file_extension(atom) :: String.t()
   def file_extension(category) do
     category
     |> get_extensions_from_category()
@@ -110,7 +110,7 @@ defmodule Faker.File do
       iex> Faker.File.file_name(:audio)
       "qui.wav"
   """
-  @spec file_name(:atom) :: String.t()
+  @spec file_name(atom) :: String.t()
   def file_name(category) do
     Lorem.word() <> "." <> file_extension(category)
   end
@@ -152,7 +152,7 @@ defmodule Faker.File do
       iex> Faker.File.mime_type(:video)
       "video/mpeg"
   """
-  @spec mime_type(:atom) :: String.t()
+  @spec mime_type(atom) :: String.t()
   def mime_type(category) do
     category
     |> get_mimes_from_category()


### PR DESCRIPTION
Some functions were using `:atom` which just refers to the `atom` atom, instead of the keyword `atom`.
