### PR TITLE
Fix Italian fiscal code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 - `Faker.Currency.code/0` remove duplicates/replace old currencies [[@yassinrais](https://github.com/yassinrais)]
 - `Faker.Adress.PtBr` - fix model documentation [[@laraujo7](https://github.com/laraujo7)]
 - `Faker.Address.En/0` corrected formatting for US and Britian [[@atavistock](https://github.com/atavistock)]
+- `Faker.Gov.It.fiscal_code/0` - fix fiscal code generation [[@CostantiniMatteo](https://github.com/CostantiniMatteo)]
 
 ### Security
 


### PR DESCRIPTION
There were some bugs in the generation of the fiscal code that failed validity checks in our codebase:

- The rule for the three characters in name and surname is: first the consonants, then the vowels, then pad right with `X`s if the name is too short (e.g. "Xi" -> "XIX"). The generator did not follow the rule and mixed vowels and consonants. To keep the code simpler the new implementation just uses consonants, therefore only a subset of valid fiscal codes are generated. If you want, I can change it to also add vowels and account for 1 and 2 letter names.
- Birth dates could've been invalid (e.g. 2020-02-31)
- Birth day didn't account properly for female sex (male rule is to just use the day number; female rule is to add 40 to that. So allowed ranges are 1-31 and 41-71)
- The numeric part of town codes for foreign countries is in the range 100-999 and not 000-999

I didn't add any test as I don't know how to properly test those fixes besides some kind of property-based testing and fuzzing, but since it's not used in the codebase I avoided adding it. Let me know if you'd like some kind of test. 

- [x] USAGE.md docs if applicable
- [x] CHANGELOG.md
