### PR TITLE
Fix Elixir 1.17 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+- Fix runtime warning on Elixir 1.17 [[@ypconstante](https://github.com/ypconstante)]
+
 ### Security
 
 ## 0.18.0

--- a/lib/faker.ex
+++ b/lib/faker.ex
@@ -47,7 +47,7 @@ defmodule Faker do
     acc
   end
 
-  @alphabet 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+  @alphabet ~c"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
   defp letter do
     Enum.at(@alphabet, random_between(0, Enum.count(@alphabet) - 1))
   end

--- a/lib/faker.ex
+++ b/lib/faker.ex
@@ -106,7 +106,7 @@ defmodule Faker do
   """
   @spec random_uniform() :: float
   def random_uniform do
-    Application.get_env(:faker, :random_module).random_uniform
+    Application.get_env(:faker, :random_module).random_uniform()
   end
 
   @doc """

--- a/lib/faker/address.ex
+++ b/lib/faker/address.ex
@@ -3,7 +3,7 @@ defmodule Faker.Address do
 
   alias Faker.Person
 
-  @geobase32 '0123456789bcdefghjkmnpqrstuvwxyz'
+  @geobase32 ~c"0123456789bcdefghjkmnpqrstuvwxyz"
 
   @moduledoc """
   Functions for generating addresses.

--- a/lib/faker/avatar.ex
+++ b/lib/faker/avatar.ex
@@ -29,13 +29,13 @@ defmodule Faker.Avatar do
 
   ## Examples
 
-      iex> Faker.Avatar.image_url('faker')
+      iex> Faker.Avatar.image_url("faker")
       "https://robohash.org/faker"
-      iex> Faker.Avatar.image_url('elixir')
+      iex> Faker.Avatar.image_url("elixir")
       "https://robohash.org/elixir"
-      iex> Faker.Avatar.image_url('plug')
+      iex> Faker.Avatar.image_url("plug")
       "https://robohash.org/plug"
-      iex> Faker.Avatar.image_url('ecto')
+      iex> Faker.Avatar.image_url("ecto")
       "https://robohash.org/ecto"
   """
   @spec image_url(binary) :: String.t()
@@ -70,13 +70,13 @@ defmodule Faker.Avatar do
 
   ## Examples
 
-      iex> Faker.Avatar.image_url('phoenix', 100, 100)
+      iex> Faker.Avatar.image_url("phoenix", 100, 100)
       "https://robohash.org/phoenix?size=100x100"
-      iex> Faker.Avatar.image_url('haskell', 200, 200)
+      iex> Faker.Avatar.image_url("haskell", 200, 200)
       "https://robohash.org/haskell?size=200x200"
-      iex> Faker.Avatar.image_url('ocaml', 300, 300)
+      iex> Faker.Avatar.image_url("ocaml", 300, 300)
       "https://robohash.org/ocaml?size=300x300"
-      iex> Faker.Avatar.image_url('idris', 400, 400)
+      iex> Faker.Avatar.image_url("idris", 400, 400)
       "https://robohash.org/idris?size=400x400"
   """
   @spec image_url(binary, integer, integer) :: String.t()

--- a/lib/faker/lorem.ex
+++ b/lib/faker/lorem.ex
@@ -285,13 +285,13 @@ defmodule Faker.Lorem do
   ## Examples
 
       iex> Faker.Lorem.characters()
-      'ppkQqaIfGqxsjFoNITNnu6eXyJicLJNth88PrhGDhwp4LNQMt5pCFh7XGEZUiBOjqwcnSUTH94vu8a9XKUwNAs48lHzPITbFXSfTS0pHfBSmHkbj9kOsd7qRuGeXKTgCgI1idI3uwENwTqc'
+      ~c'ppkQqaIfGqxsjFoNITNnu6eXyJicLJNth88PrhGDhwp4LNQMt5pCFh7XGEZUiBOjqwcnSUTH94vu8a9XKUwNAs48lHzPITbFXSfTS0pHfBSmHkbj9kOsd7qRuGeXKTgCgI1idI3uwENwTqc'
       iex> Faker.Lorem.characters(3..5)
-      'EFbv'
+      ~c'EFbv'
       iex> Faker.Lorem.characters(2)
-      'vx'
+      ~c'vx'
       iex> Faker.Lorem.characters(7)
-      'jycADSd'
+      ~c'jycADSd'
   """
   @spec characters(integer | Range.t()) :: [char]
   def characters(range_or_length \\ 15..255)
@@ -498,7 +498,7 @@ defmodule Faker.Lorem do
   end
 
   defp character do
-    alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    alphabet = ~c"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
     Enum.at(alphabet, Faker.random_between(0, Enum.count(alphabet) - 1))
   end
 end


### PR DESCRIPTION
This fixes some of the warnings being logged when using Elixir 1.17
- Fix compilation warnings caused by single quote usages. In some places I changed to double quotes, in others to `~c` 
- Fix runtime warning on Faker.random_uniform/0 caused by missing parenthesis in function call

There are still some warnings because of pattern matching on ranges, but fixing this requires an API change or bumping the minimum Elixir version to 1.12 to be able to match or ignore the range step.

Closes https://github.com/elixirs/faker/issues/558

I've added:

- [ ] USAGE.md docs if applicable
- [X] CHANGELOG.md
