### PR TITLE
Fix range pattern matching warning on Elixir 1.17 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
-- Fix runtime warning on Elixir 1.17 [[@ypconstante](https://github.com/ypconstante)]
+- Fix compile and runtime warnings on Elixir 1.17 [[@ypconstante](https://github.com/ypconstante)]
 
 ### Security
 

--- a/lib/faker/lorem.ex
+++ b/lib/faker/lorem.ex
@@ -296,16 +296,18 @@ defmodule Faker.Lorem do
   @spec characters(integer | Range.t()) :: [char]
   def characters(range_or_length \\ 15..255)
 
-  def characters(first..last) do
-    characters(Faker.random_between(first, last))
-  end
-
-  def characters(num) do
+  def characters(num) when is_integer(num) do
     char = &character/0
 
     char
     |> Stream.repeatedly()
     |> Enum.take(num)
+  end
+
+  def characters(range) do
+    range
+    |> Util.pick()
+    |> characters()
   end
 
   @doc """
@@ -330,12 +332,14 @@ defmodule Faker.Lorem do
   @spec paragraph(integer | Range.t()) :: String.t()
   def paragraph(range \\ 2..5)
 
-  def paragraph(first..last) do
-    paragraph(Faker.random_between(first, last))
+  def paragraph(num) when is_integer(num) do
+    Enum.join(sentences(num), " ")
   end
 
-  def paragraph(num) do
-    Enum.join(sentences(num), " ")
+  def paragraph(range) do
+    range
+    |> Util.pick()
+    |> paragraph()
   end
 
   @doc """
@@ -360,16 +364,18 @@ defmodule Faker.Lorem do
   @spec paragraphs(integer | Range.t()) :: list(String.t())
   def paragraphs(range \\ 2..5)
 
-  def paragraphs(first..last) do
-    paragraphs(Faker.random_between(first, last))
-  end
-
-  def paragraphs(num) do
+  def paragraphs(num) when is_integer(num) do
     paragraph = &paragraph/0
 
     paragraph
     |> Stream.repeatedly()
     |> Enum.take(num)
+  end
+
+  def paragraphs(range) do
+    range
+    |> Util.pick()
+    |> paragraphs()
   end
 
   @doc """
@@ -394,13 +400,14 @@ defmodule Faker.Lorem do
   @spec sentence(integer | Range.t()) :: String.t()
   def sentence(range \\ 4..10)
 
-  def sentence(first..last) do
-    Faker.random_between(first, last)
-    |> sentence(Util.pick([".", ".", ".", "!", "?"]))
+  def sentence(num) when is_integer(num) do
+    sentence(num, Util.pick([".", ".", ".", "!", "?"]))
   end
 
-  def sentence(num) do
-    sentence(num, Util.pick([".", ".", ".", "!", "?"]))
+  def sentence(range) do
+    range
+    |> Util.pick()
+    |> sentence()
   end
 
   @doc """
@@ -451,16 +458,18 @@ defmodule Faker.Lorem do
   @spec sentences(integer | Range.t()) :: [String.t()]
   def sentences(range \\ 2..5)
 
-  def sentences(first..last) do
-    sentences(Faker.random_between(first, last))
-  end
-
-  def sentences(num) do
+  def sentences(num) when is_integer(num) do
     sentence = &sentence/0
 
     sentence
     |> Stream.repeatedly()
     |> Enum.take(num)
+  end
+
+  def sentences(range) do
+    range
+    |> Util.pick()
+    |> sentences()
   end
 
   @doc """
@@ -485,16 +494,18 @@ defmodule Faker.Lorem do
   @spec words(integer | Range.t()) :: [String.t()]
   def words(range \\ 3..6)
 
-  def words(first..last) do
-    words(Faker.random_between(first, last))
-  end
-
-  def words(num) do
+  def words(num) when is_integer(num) do
     word = &word/0
 
     word
     |> Stream.repeatedly()
     |> Enum.take(num)
+  end
+
+  def words(range) do
+    range
+    |> Util.pick()
+    |> words()
   end
 
   defp character do

--- a/lib/faker/pizza.ex
+++ b/lib/faker/pizza.ex
@@ -44,17 +44,18 @@ defmodule Faker.Pizza do
         "Family with Clam, Cherry Tomatoes, Salmon, and Chicken"
       ]
   """
-  @spec pizzas(Range.t()) :: list(String.t())
+  @spec pizzas(integer | Range.t()) :: list(String.t())
   def pizzas(range \\ 2..5)
 
-  def pizzas(first..last) do
-    pizzas(Faker.random_between(first, last))
-  end
-
-  @spec pizzas(integer) :: list(String.t())
-  def pizzas(num) do
+  def pizzas(num) when is_integer(num) do
     stream = Stream.repeatedly(&pizza/0)
     Enum.take(stream, num)
+  end
+
+  def pizzas(range) do
+    range
+    |> Util.pick()
+    |> pizzas()
   end
 
   @doc """
@@ -99,17 +100,18 @@ defmodule Faker.Pizza do
       iex> Faker.Pizza.toppings(2..3)
       ["Shellfish", "Smoked Salmon"]
   """
-  @spec toppings(Range.t()) :: list(String.t())
+  @spec toppings(integer | Range.t()) :: list(String.t())
   def toppings(range \\ 2..5)
 
-  def toppings(first..last) do
-    toppings(Faker.random_between(first, last))
-  end
-
-  @spec toppings(integer) :: list(String.t())
-  def toppings(num) do
+  def toppings(num) when is_integer(num) do
     stream = Stream.repeatedly(&topping/0)
     Enum.take(stream, num)
+  end
+
+  def toppings(range) do
+    range
+    |> Util.pick()
+    |> toppings()
   end
 
   defp toppings_sentence(num) do


### PR DESCRIPTION
On #561 I said that fixing the range pattern matching would require API changes or bumping the minimum Elixir version. It turns out that `Faker.Util.pick` is implemented in a way that already works on ranges with step. 

This PR migrates all the places using pattern matching on ranges to use `pick`, fixing all remaining warnings on Elixir 1.17.

I've added:

- [ ] USAGE.md docs if applicable
- [X] CHANGELOG.md
