### PR TITLE
chore(config): pin Erlang/Elixir for Renovate lockfile updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "lockFileMaintenance": { "enabled": true }
+  "lockFileMaintenance": { "enabled": true },
+  "constraints": {
+    "erlang": "^29",
+    "elixir": "^1.20"
+  }
 }


### PR DESCRIPTION
## Why

Every Renovate PR that needs a `mix.lock` update currently fails its `renovate/artifacts` step (e.g. #667) with:

```
File name: mix.lock
Command failed: install-tool elixir v1.20.2
```

Root cause: Renovate's `mix` manager installs the **latest Elixir** (1.20.2) but defaults the Erlang tool constraint to a hardcoded `^26` ([`lib/modules/manager/mix/artifacts.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/mix/artifacts.ts)). Elixir 1.20 dropped OTP 26 — its releases only ship `elixir-otp-27/28/29` builds — so containerbase installs an OTP-27-compiled Elixir onto an OTP 26 runtime and crashes running `mix local.hex`.

## What

Pin compatible tool versions via [`constraints`](https://docs.renovatebot.com/configuration-options/#constraints), mirroring the newest CI matrix entry (Elixir 1.20 / OTP 29). The `erlang` line is the essential one; `elixir` documents the pair explicitly.

After this merges, ticking the rebase checkbox on #667 should make Renovate regenerate `mix.lock` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)